### PR TITLE
feat(analytics): wire up GA4 (G-P2JVEP5KYX) site-wide

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,6 +12,7 @@ import { Inter, Playfair_Display, DM_Sans, Noto_Nastaliq_Urdu } from "next/font/
 // Phase 2 #8.9 — PWA shell.
 import { PwaRegister } from "@/components/pwa/pwa-register"
 import { PwaInstallPrompt } from "@/components/pwa/install-prompt"
+import { GoogleAnalytics } from "@/components/analytics/google-analytics"
 import {
   SITE_URL,
   SITE_NAME,
@@ -190,6 +191,7 @@ export default function RootLayout({
         className={`${inter.variable} ${playfair.variable} ${dmSans.variable} ${nastaliq.variable} font-sans`}
         suppressHydrationWarning
       >
+        <GoogleAnalytics />
         <QueryProvider>
           <UserProvider>
             <BusinessProvider>

--- a/components/analytics/google-analytics.tsx
+++ b/components/analytics/google-analytics.tsx
@@ -1,0 +1,28 @@
+import Script from "next/script"
+
+/**
+ * GA4 (gtag.js). Measurement ID `G-P2JVEP5KYX` is the live default so analytics
+ * works without any env config; NEXT_PUBLIC_GA_MEASUREMENT_ID can still override
+ * it per-environment if needed.
+ *
+ * `afterInteractive` keeps analytics off the critical render path (no LCP/INP
+ * hit) while emitting the exact same gtag calls as the standard snippet.
+ */
+export function GoogleAnalytics() {
+  const id = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || "G-P2JVEP5KYX"
+
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${id}`}
+        strategy="afterInteractive"
+      />
+      <Script id="ga4-init" strategy="afterInteractive">
+        {`window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', '${id}');`}
+      </Script>
+    </>
+  )
+}


### PR DESCRIPTION
Activate Google Analytics 4 across the app. The GoogleAnalytics component was previously dormant — gated on NEXT_PUBLIC_GA_MEASUREMENT_ID which was never set, so no analytics actually shipped.

Hardcode G-P2JVEP5KYX as the live default (the env var still overrides for per-environment streams) and mount <GoogleAnalytics /> in the root layout. Loaded via next/script afterInteractive so it stays off the critical render path — emits the same gtag calls as the standard snippet with no LCP/INP hit.