### PR TITLE
feat(seo): bridal-dress silo + photography-cost guide + money-page pr…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ yarn-error.log*
 
 # local env files
 .env*.local
+.env
+.env.*
+!.env.example
 
 # vercel
 .vercel

--- a/app/(main)/barat-dress-for-bride/page.tsx
+++ b/app/(main)/barat-dress-for-bride/page.tsx
@@ -1,0 +1,8 @@
+import { ContentPillar, buildPillarMetadata } from "@/components/content/content-pillar"
+import { data } from "@/lib/content/pillars/barat-dress-for-bride"
+
+export const metadata = buildPillarMetadata(data)
+
+export default function Page() {
+  return <ContentPillar data={data} />
+}

--- a/app/(main)/mehndi-dress-for-bride/page.tsx
+++ b/app/(main)/mehndi-dress-for-bride/page.tsx
@@ -1,0 +1,8 @@
+import { ContentPillar, buildPillarMetadata } from "@/components/content/content-pillar"
+import { data } from "@/lib/content/pillars/mehndi-dress-for-bride"
+
+export const metadata = buildPillarMetadata(data)
+
+export default function Page() {
+  return <ContentPillar data={data} />
+}

--- a/app/(main)/nikkah-dress-for-bride/page.tsx
+++ b/app/(main)/nikkah-dress-for-bride/page.tsx
@@ -1,0 +1,8 @@
+import { ContentPillar, buildPillarMetadata } from "@/components/content/content-pillar"
+import { data } from "@/lib/content/pillars/nikkah-dress-for-bride"
+
+export const metadata = buildPillarMetadata(data)
+
+export default function Page() {
+  return <ContentPillar data={data} />
+}

--- a/app/(main)/pakistani-bridal-dress-guide/page.tsx
+++ b/app/(main)/pakistani-bridal-dress-guide/page.tsx
@@ -1,0 +1,8 @@
+import { ContentPillar, buildPillarMetadata } from "@/components/content/content-pillar"
+import { data } from "@/lib/content/pillars/pakistani-bridal-dress-guide"
+
+export const metadata = buildPillarMetadata(data)
+
+export default function Page() {
+  return <ContentPillar data={data} />
+}

--- a/app/(main)/walima-dress-for-bride/page.tsx
+++ b/app/(main)/walima-dress-for-bride/page.tsx
@@ -1,0 +1,8 @@
+import { ContentPillar, buildPillarMetadata } from "@/components/content/content-pillar"
+import { data } from "@/lib/content/pillars/walima-dress-for-bride"
+
+export const metadata = buildPillarMetadata(data)
+
+export default function Page() {
+  return <ContentPillar data={data} />
+}

--- a/app/(main)/wedding-photography-cost-in-lahore/page.tsx
+++ b/app/(main)/wedding-photography-cost-in-lahore/page.tsx
@@ -1,0 +1,8 @@
+import { ContentPillar, buildPillarMetadata } from "@/components/content/content-pillar"
+import { data } from "@/lib/content/pillars/wedding-photography-cost-in-lahore"
+
+export const metadata = buildPillarMetadata(data)
+
+export default function Page() {
+  return <ContentPillar data={data} />
+}

--- a/components/seo/vendor-type-city-page.tsx
+++ b/components/seo/vendor-type-city-page.tsx
@@ -27,6 +27,11 @@ import {
 import { Breadcrumbs } from "@/components/seo/breadcrumbs"
 import { fetchCityVendors, type VendorListItem } from "@/lib/seo/fetch-vendors"
 import { getCityEditorial, getVendorTypeGuide } from "@/lib/seo/city-editorial"
+import {
+  getVendorTypePricing,
+  getVendorTypeQuestions,
+  getVendorTypeGuidePillar,
+} from "@/lib/seo/pricing-guide"
 
 export function generateVendorTypeCityStaticParams() {
   return CITIES.map((c) => ({ city: c.slug }))
@@ -85,6 +90,9 @@ export async function VendorTypeCityPage({
   const hasListings = vendors.length > 0
   const editorial = getCityEditorial(city.slug)
   const guide = getVendorTypeGuide(vt.slug)
+  const pricing = getVendorTypePricing(vt.slug)
+  const questions = getVendorTypeQuestions(vt.slug)
+  const guidePillar = getVendorTypeGuidePillar(vt.slug)
 
   const url = `${SITE_URL}/${vt.slug}/${city.slug}`
   const priceRangeStr = formatPriceRange(vendors)
@@ -130,6 +138,16 @@ export async function VendorTypeCityPage({
       question: `What if my ${vt.singular.toLowerCase()} cancels?`,
       answer: `${SITE_NAME} holds the deposit until the vendor confirms. If a vendor cancels last-minute, we help you find a replacement and refund per our cancellation policy.`,
     },
+    ...(pricing
+      ? [
+          {
+            question: `What's included at different ${vt.singular.toLowerCase()} price points in ${city.name}?`,
+            answer: `${pricing.tiers
+              .map((t) => `${t.tier} (${t.band}): ${t.includes}`)
+              .join(" ")} ${pricing.note}`,
+          },
+        ]
+      : []),
   ]
 
   const ld = combineGraph(collectionLd, svcLd, faqLD(faqs))
@@ -307,6 +325,74 @@ export async function VendorTypeCityPage({
             </p>
           </div>
         </section>
+
+        {pricing && (
+          <section className="mb-12">
+            <h2 className="font-display italic text-[24px] text-bridal-charcoal mb-5">
+              What does a {vt.singular.toLowerCase()} in {city.name} cost?
+            </h2>
+            <div className="overflow-x-auto max-w-3xl">
+              <table className="w-full border-collapse font-bridal text-[14px]">
+                <thead>
+                  <tr className="border-b border-bridal-beige text-left">
+                    <th className="py-2 pr-4 font-semibold text-bridal-charcoal">Tier</th>
+                    <th className="py-2 pr-4 font-semibold text-bridal-charcoal whitespace-nowrap">
+                      Indicative PKR
+                    </th>
+                    <th className="py-2 font-semibold text-bridal-charcoal">
+                      Typically includes
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {pricing.tiers.map((t) => (
+                    <tr
+                      key={t.tier}
+                      className="border-b border-bridal-beige/60 align-top"
+                    >
+                      <td className="py-3 pr-4 font-semibold text-bridal-charcoal whitespace-nowrap">
+                        {t.tier}
+                      </td>
+                      <td className="py-3 pr-4 text-bridal-charcoal whitespace-nowrap">
+                        {t.band}
+                      </td>
+                      <td className="py-3 text-bridal-text leading-relaxed">
+                        {t.includes}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <p className="mt-3 max-w-3xl font-bridal text-[12.5px] italic text-bridal-text-soft">
+              {pricing.note}
+            </p>
+            {guidePillar && (
+              <p className="mt-4 font-bridal text-[14px]">
+                <Link
+                  href={guidePillar.href}
+                  className="text-bridal-gold font-semibold hover:underline"
+                >
+                  {guidePillar.label} →
+                </Link>
+              </p>
+            )}
+          </section>
+        )}
+
+        {questions.length > 0 && (
+          <section className="mb-12">
+            <h2 className="font-display italic text-[24px] text-bridal-charcoal mb-5">
+              Questions to ask before booking a {vt.singular.toLowerCase()} in{" "}
+              {city.name}
+            </h2>
+            <ul className="max-w-3xl list-disc space-y-2 pl-5 font-bridal text-[14px] text-bridal-text leading-relaxed">
+              {questions.map((q) => (
+                <li key={q}>{q}</li>
+              ))}
+            </ul>
+          </section>
+        )}
 
         <section className="mb-12">
           <h2 className="font-display italic text-[24px] text-bridal-charcoal mb-5">

--- a/lib/content/pillars/barat-dress-for-bride.ts
+++ b/lib/content/pillars/barat-dress-for-bride.ts
@@ -1,0 +1,412 @@
+import type { PillarData } from "@/lib/content/pillar-types"
+
+export const data: PillarData = {
+  "slug": "barat-dress-for-bride",
+  "title": "Barat Dress for Bride 2026: Colours, Silhouettes & Styling for the Pakistani Barat",
+  "h1": "Barat Dress for the Bride: Colours, Silhouettes, Embellishment & Styling",
+  "metaDescription": "A Pakistan-specific guide to the bridal barat dress: traditional red and maroon palettes, lehenga vs gharara silhouettes, embellishment, jewellery, designers and cost bands.",
+  "eyebrow": "Bridal Attire Guide",
+  "updatedLabel": "June 2026",
+  "lead": "The barat is the bride's most formal moment, and the traditional choice is a heavily embellished lehenga-choli or gharara in deep red or maroon — the colours long associated with the Pakistani bride. Deep gold, rust and emerald are now widely accepted alternatives. This guide covers colours and symbolism, silhouettes, embellishment and comfort, dupatta draping, jewellery pairing and how to coordinate with the groom and your photographer.",
+  "authorName": "Wedding Wala Editorial Team",
+  "breadcrumb": [
+    {
+      "name": "Home",
+      "href": "/"
+    },
+    {
+      "name": "Blog",
+      "href": "/blog"
+    },
+    {
+      "name": "Barat Dress for Bride",
+      "href": "/barat-dress-for-bride"
+    }
+  ],
+  "sections": [
+    {
+      "type": "h2",
+      "text": "What is the barat dress? (and why it's the bride's most formal look)"
+    },
+    {
+      "type": "p",
+      "text": "The barat is the function where the groom's family arrives to take the bride home, and traditionally it carries the heaviest, most ceremonial outfit the bride wears across the whole wedding. The classic barat dress is a richly embellished lehenga-choli or gharara — long on embroidery, structured in cut, and built around the bride's signature colour. Because it anchors the central wedding day and almost every formal portrait, it is the single outfit most brides invest the most time, budget and emotion into. For where the barat sits in the wider sequence, see our Pakistani wedding events order guide and the dedicated barat traditions guide."
+    },
+    {
+      "type": "callout",
+      "text": "The barat is part of a wider bridal wardrobe — Mayun, Mehndi, Nikah, Barat and Walima each have their own mood. The barat is the maximalist, heavily-worked end of the spectrum; the Walima look is deliberately lighter and more elegant. Plan the barat dress as the anchor, then balance the rest of the events around it.",
+      "label": "Where the barat fits"
+    },
+    {
+      "type": "h2",
+      "text": "Barat colours & their symbolism"
+    },
+    {
+      "type": "p",
+      "text": "Red and maroon remain the heart of the Pakistani barat palette. Deep red carries strong cultural weight — it is conventionally linked with celebration, prosperity and the married woman — which is why it has stayed the default barat colour for generations. That said, the palette has genuinely broadened: deep gold, rust, maroon-with-gold, and emerald or bottle green are all now widely worn on the barat without raising an eyebrow. Choosing outside pure red is a matter of personal taste, not a breach of etiquette."
+    },
+    {
+      "type": "table",
+      "caption": "Table A — Barat colours and what they signal",
+      "headers": [
+        "Colour",
+        "Mood / association",
+        "Best for"
+      ],
+      "rows": [
+        [
+          "Deep red / crimson",
+          "The traditional bridal colour; celebration and prosperity",
+          "Brides wanting the classic, timeless barat look"
+        ],
+        [
+          "Maroon / wine",
+          "Slightly softer, richer and modern; very photogenic",
+          "A contemporary take on the traditional red"
+        ],
+        [
+          "Deep gold / antique gold",
+          "Regal and warm; pairs with most jewellery",
+          "Evening barats and warm skin tones"
+        ],
+        [
+          "Rust / brick",
+          "Earthy, on-trend, less common",
+          "Brides who want red-family without pure red"
+        ],
+        [
+          "Emerald / bottle green",
+          "Striking, jewel-toned alternative",
+          "A bold, non-traditional but accepted choice"
+        ]
+      ]
+    },
+    {
+      "type": "callout",
+      "text": "Pure white and ivory are conventionally reserved for the Nikah look and read as understated rather than celebratory, so they are rarely chosen for the barat. This is etiquette and styling convention, not a strict rule — but most brides keep white for the Nikah and bring the colour out for the barat.",
+      "label": "Convention, not a rule"
+    },
+    {
+      "type": "h2",
+      "text": "Barat silhouettes: lehenga, gharara, sharara & more"
+    },
+    {
+      "type": "p",
+      "text": "The barat outfit is almost always a heavy ensemble built from a fitted choli (blouse) or kurti, a voluminous lower garment, and a worked dupatta. The lehenga-choli is the most common modern barat silhouette, but the gharara and sharara carry strong traditional and regional appeal — particularly in families with Lucknowi or Hyderabadi heritage. Match the silhouette to your height, comfort and the formality of the venue."
+    },
+    {
+      "type": "table",
+      "caption": "Table B — Barat silhouettes compared",
+      "headers": [
+        "Silhouette",
+        "Description",
+        "Feel",
+        "Suits"
+      ],
+      "rows": [
+        [
+          "Lehenga-choli",
+          "Flared skirt + fitted choli + dupatta",
+          "Most popular, versatile, photogenic",
+          "Most body types; the safe modern default"
+        ],
+        [
+          "Gharara",
+          "Wide flared trousers gathered at the knee + short kurti",
+          "Traditional, regal, heritage",
+          "Brides wanting a classic, cultural look"
+        ],
+        [
+          "Sharara",
+          "Wide-leg flared trousers (no knee gather) + kurti",
+          "Flowing, comfortable, elegant",
+          "Taller brides and those prioritising movement"
+        ],
+        [
+          "Farshi gharara",
+          "Floor-trailing, voluminous heritage gharara",
+          "Grand, royal, statement",
+          "Formal evening barats; dramatic entrances"
+        ],
+        [
+          "Bridal maxi / gown",
+          "Long, fitted-to-flared single piece",
+          "Modern, sleek, fusion",
+          "Brides wanting a non-traditional silhouette"
+        ]
+      ]
+    },
+    {
+      "type": "h3",
+      "text": "Lehenga vs gharara — how to choose"
+    },
+    {
+      "type": "p",
+      "text": "A lehenga gives you the widest choice of cuts, the most flattering structure for most body types, and the easiest movement for sitting on the stage and posing. A gharara or sharara leans into heritage and is often the family-tradition choice; the gharara reads more formal and structured, while the sharara flows and tends to be more comfortable to walk in. If you are unsure, a lehenga is the reliable default; choose a gharara when the cultural weight matters to you or your family."
+    },
+    {
+      "type": "h2",
+      "text": "Embellishment, weight & comfort"
+    },
+    {
+      "type": "p",
+      "text": "Barat dresses are defined by their handwork — and that handwork has real weight. Common Pakistani embellishment techniques include zardozi, dabka, kora, nakshi, gota, mukaish, sequins, kundan and stone or crystal work, often layered together on the choli, skirt borders and dupatta. The denser the embroidery, the heavier and warmer the garment, which matters a great deal across a long barat that runs into the night."
+    },
+    {
+      "type": "table",
+      "caption": "Table C — Embellishment vs weight & comfort",
+      "headers": [
+        "Embellishment level",
+        "Typical weight",
+        "Comfort over a long barat",
+        "Best for"
+      ],
+      "rows": [
+        [
+          "Maximal (full zardozi, dense dabka, heavy borders)",
+          "Heavy",
+          "Plan for breaks; harder to sit and move",
+          "Grand entrances; short stage-focused barats"
+        ],
+        [
+          "Balanced (worked panels + lighter ground)",
+          "Medium",
+          "Manageable for most of the evening",
+          "Most brides; the practical sweet spot"
+        ],
+        [
+          "Lighter (border-focused, lighter ground fabric)",
+          "Light–medium",
+          "Most comfortable; easiest to move in",
+          "Summer barats, longer functions, petite brides"
+        ]
+      ]
+    },
+    {
+      "type": "callout",
+      "text": "Ask to wear the full ensemble — choli, skirt and dupatta together — at your final fitting, then sit, stand and walk a few steps. A barat dress that looks perfect on a hanger can be exhausting after several hours on stage. Weight, blouse fit and dupatta pinning are the three comfort details most worth testing in advance.",
+      "label": "Comfort tip"
+    },
+    {
+      "type": "h2",
+      "text": "Dupatta draping for the barat"
+    },
+    {
+      "type": "p",
+      "text": "The dupatta is a defining part of the barat look, and how it is draped changes the whole silhouette. Many brides use a double-dupatta setup: one pinned over the head (and sometimes secured with a matha patti or maang tikka) and a second draped across the body or shoulder. Discuss the drape with your makeup artist and a helper in advance, because a heavy, well-pinned dupatta needs setting up — and re-pinning during the evening."
+    },
+    {
+      "type": "ul",
+      "items": [
+        "Head-drape (single): one dupatta pinned over the head, framing the face and jewellery — the classic, traditional look.",
+        "Double dupatta: one over the head plus a second across the body or shoulder for fullness and grandeur.",
+        "Shoulder / one-side drape: a more modern, lighter option that shows the choli detailing.",
+        "Spread-behind drape: the dupatta fanned out behind on the stage for portraits, then re-pinned for movement.",
+        "Secure the head-drape with a matha patti, maang tikka or pins so it stays put through the photo session."
+      ]
+    },
+    {
+      "type": "h2",
+      "text": "Jewellery pairing for the barat"
+    },
+    {
+      "type": "p",
+      "text": "Barat jewellery is layered and statement-making, designed to balance the heavy outfit. The traditional set is led by a matha patti or maang tikka across the forehead and hairline, a jhoomar (passa) pinned to one side, and a substantial necklace — often a choker layered with a longer rani haar. Match the metal tone to your dress: antique or gold-tone jewellery sits beautifully on red, maroon and gold ensembles, while polki and kundan suit traditional palettes."
+    },
+    {
+      "type": "table",
+      "caption": "Table D — Barat jewellery checklist",
+      "headers": [
+        "Piece",
+        "Where it sits",
+        "Note"
+      ],
+      "rows": [
+        [
+          "Matha patti / maang tikka",
+          "Forehead and hairline parting",
+          "Anchors the head-drape; the bridal centrepiece"
+        ],
+        [
+          "Jhoomar (passa)",
+          "Pinned to one side of the head",
+          "Traditional, regal accent"
+        ],
+        [
+          "Choker + rani haar",
+          "Neck (layered short + long)",
+          "Balances a heavy embellished choli"
+        ],
+        [
+          "Jhumka / chandbali earrings",
+          "Ears",
+          "Often the heaviest single piece; check weight"
+        ],
+        [
+          "Nath (nose ring)",
+          "Nose, chained to the hair",
+          "Strongly traditional; optional by family"
+        ],
+        [
+          "Haath phool / bangles",
+          "Hands and wrists",
+          "Complete the bridal hands for portraits"
+        ]
+      ]
+    },
+    {
+      "type": "h2",
+      "text": "Designers & where brides shop"
+    },
+    {
+      "type": "p",
+      "text": "Pakistan has a deep bench of bridal designers, from couture houses to accessible bridal retail. Names frequently associated with barat-grade bridal wear include Kashee's, HSY, Nomi Ansari, Elan, Zara Shahjahan, Ali Xeeshan, Suffuse by Sana Yasir, Zainab Chottani, Sania Maskatiya, Maria B and Faraz Manan. Couture pieces sit at the top of the market; established bridal studios and local master tailors offer mid-range custom work; and ready-to-wear or rental routes serve tighter budgets. Browse bridal-wear vendors near you to compare studios and price points."
+    },
+    {
+      "type": "h2",
+      "text": "Indicative cost bands & buy vs rent"
+    },
+    {
+      "type": "p",
+      "text": "Barat dresses span an enormous price range, driven mainly by embroidery density, fabric, designer name and city. The guidance below is qualitative — High / Mid / Low bands only — and is synthesised from third-party bridal-retail references. These are not Wedding Wala quotes. Custom couture from a named designer sits at the top; a mid-range studio or skilled tailor offers strong value; and ready-to-wear or rental is the budget-conscious route for a single-use outfit."
+    },
+    {
+      "type": "table",
+      "caption": "Table E — Buy vs rent vs ready-to-wear (cost bands indicative only)",
+      "headers": [
+        "Route",
+        "Indicative cost band*",
+        "Lead time",
+        "Best for"
+      ],
+      "rows": [
+        [
+          "Custom couture (named designer)",
+          "High (varies widely)",
+          "3–6 months; book early",
+          "Brides wanting a signature designer piece and keepsake"
+        ],
+        [
+          "Mid-range studio / master tailor",
+          "Mid",
+          "2–4 months",
+          "Custom fit and design at better value"
+        ],
+        [
+          "Ready-to-wear (minor alteration)",
+          "Mid–Low",
+          "Weeks",
+          "Faster turnaround, standard fit"
+        ],
+        [
+          "Rental",
+          "Typically a fraction of buying",
+          "Days–weeks",
+          "Single-use, budget-conscious brides"
+        ]
+      ]
+    },
+    {
+      "type": "callout",
+      "text": "The cost bands here are indicative qualitative ranges drawn from third-party bridal-retail and designer references — they are not verified Wedding Wala prices. A barat dress depends heavily on embroidery density, fabric, designer and city, so always confirm current pricing directly with the vendor. Rental is usually a fraction of buying, but a heavily customised couture piece can run many times the cost of a ready-to-wear option.",
+      "label": "Honesty note on pricing"
+    },
+    {
+      "type": "h3",
+      "text": "When to order your barat dress"
+    },
+    {
+      "type": "p",
+      "text": "Bridal couture and heavy custom work need lead time. As a Pakistani planning point, aim to start 3–6 months ahead for a custom barat dress — and earlier still for the November–February peak wedding season, when the best designers and karigars (artisans) are fully booked. Ready-to-wear with alterations can be turned around in weeks, and rental in days. Build the order date into your overall wedding checklist and timeline so fittings do not collide with the final crunch."
+    },
+    {
+      "type": "h2",
+      "text": "Coordinating with the groom & your photographer"
+    },
+    {
+      "type": "p",
+      "text": "The barat is where the bride and groom appear together in the most formal portraits, so their looks should harmonise rather than clash. Coordinate your palette with the groom's sherwani — a maroon or deep-red bridal lehenga pairs naturally with a navy, bottle-green or deep-gold sherwani, while matching exact shades can look heavy, so aim for complementary rather than identical tones. Share your colour and silhouette plan with the groom early (see our groom sherwani guide) and brief your photographer in advance, since the barat dress, jewellery and dupatta drape define the day's signature shots."
+    },
+    {
+      "type": "ul",
+      "items": [
+        "Agree a coordinated, not identical, palette with the groom — complementary jewel tones photograph best.",
+        "Tell your photographer which silhouette and dupatta drape you are wearing so they can plan stage and portrait shots.",
+        "Plan your grand entrance and stage-sitting around the weight of the outfit.",
+        "Schedule the heaviest jewellery and dupatta pinning with your makeup artist before the barat begins.",
+        "Keep a helper on hand to re-pin the dupatta and manage the train between shots."
+      ]
+    },
+    {
+      "type": "h2",
+      "text": "Find bridal-wear vendors & a photographer in your city"
+    },
+    {
+      "type": "p",
+      "text": "Browse bridal-wear studios and designers on Wedding Wala to compare barat dresses across price points, then book a wedding photographer to capture the look. Start with the bridal-wear category for your city, and explore the rest of your bridal wardrobe — including the lighter Walima dress — through the bridal dress guide hub."
+    }
+  ],
+  "faqs": [
+    {
+      "question": "What should a Pakistani bride wear on her barat?",
+      "answer": "The barat is the bride's most formal look, traditionally a heavily embellished lehenga-choli or gharara in deep red or maroon, paired with statement jewellery (matha patti, jhoomar, choker and rani haar) and a worked dupatta draped over the head. Deep gold, rust and emerald are now widely accepted alternatives to pure red."
+    },
+    {
+      "question": "What colour should the bride's barat dress be?",
+      "answer": "Red and maroon are the classic barat colours, conventionally linked with celebration and prosperity, and remain the most popular choice. The palette has broadened, though — deep gold, rust, wine and emerald or bottle green are all widely worn and accepted. Pure white and ivory are usually kept for the Nikah rather than the barat."
+    },
+    {
+      "question": "Lehenga or gharara for the barat — which is better?",
+      "answer": "A lehenga-choli is the most popular modern barat silhouette, offering the widest range of flattering cuts and easy movement for stage-sitting and portraits. A gharara or sharara is the heritage choice, often chosen for cultural or family tradition; the gharara reads more formal and structured, while the sharara flows and is more comfortable to walk in."
+    },
+    {
+      "question": "How heavy is a barat dress and how do I stay comfortable?",
+      "answer": "A fully embellished barat dress with dense zardozi and heavy borders can be genuinely heavy and warm over a long evening. Choose a balanced embellishment level if comfort matters, test the full ensemble at your final fitting by sitting and walking, and keep a helper on hand to re-pin the dupatta. Lighter, border-focused work is the most comfortable for long or summer barats."
+    },
+    {
+      "question": "What jewellery goes with a barat dress?",
+      "answer": "Barat jewellery is layered and statement-making: a matha patti or maang tikka across the forehead, a jhoomar (passa) pinned to one side, a choker layered with a longer rani haar, heavy jhumka or chandbali earrings, and optionally a nath (nose ring) and haath phool. Match the metal tone — antique gold, polki or kundan — to your dress colour."
+    },
+    {
+      "question": "How many months before the wedding should I order my barat dress?",
+      "answer": "Aim to start 3–6 months ahead for a custom barat dress, and earlier for the November–February peak season when designers and karigars are fully booked. Ready-to-wear with alterations can be turned around in weeks and rental in days, but heavy custom embroidery always needs the most lead time."
+    },
+    {
+      "question": "Is it better to buy or rent a barat dress?",
+      "answer": "Buy or custom-stitch if you want an exact fit, a signature designer piece or a keepsake. Rent if it is a single-use, budget-conscious decision — rental typically costs a fraction of buying, though this is an indicative range, so confirm with the vendor. Ready-to-wear with minor alterations sits in between on cost and turnaround."
+    },
+    {
+      "question": "How should the bride and groom coordinate their barat outfits?",
+      "answer": "Aim for complementary rather than identical colours, since the barat produces the most formal joint portraits. A maroon or deep-red bridal lehenga pairs naturally with a navy, bottle-green or deep-gold sherwani. Share your palette and silhouette with the groom early, and brief your photographer so the stage and portrait shots are planned around the look."
+    }
+  ],
+  "internalLinks": [
+    {
+      "label": "Pakistani bridal dress guide (hub)",
+      "href": "/pakistani-bridal-dress-guide"
+    },
+    {
+      "label": "Walima dress for the bride",
+      "href": "/walima-dress-for-bride"
+    },
+    {
+      "label": "Groom sherwani guide",
+      "href": "/groom-sherwani-guide-pakistan"
+    },
+    {
+      "label": "Barat traditions guide",
+      "href": "/barat-traditions-pakistani-wedding-guide"
+    },
+    {
+      "label": "Find bridal-wear vendors",
+      "href": "/bridal-wear"
+    },
+    {
+      "label": "Book a wedding photographer",
+      "href": "/wedding-photographers"
+    }
+  ],
+  "methodologyNote": "Compiled by the Wedding Wala Editorial Team. Conventions around the barat dress (red and maroon as the traditional bridal palette; the heavily embellished lehenga-choli and gharara as the most formal bridal silhouettes; layered jewellery such as the matha patti, jhoomar, choker and rani haar) are well-supported across Pakistani bridal-retail, designer and editorial references. Silhouette, embellishment, draping, jewellery and pricing guidance is synthesised across multiple Pakistani and South Asian bridal sources. Cost figures are indicative qualitative bands (High/Mid/Low) from third parties, not Wedding Wala quotes — confirm current pricing with the vendor. Designer names are referenced as well-known Pakistani bridal houses without any associated prices. Colour and styling conventions are stated as etiquette, not strict rules.",
+  "publishedAt": "2026-06-15",
+  "updatedAt": "2026-06-15"
+}

--- a/lib/content/pillars/index.ts
+++ b/lib/content/pillars/index.ts
@@ -31,6 +31,12 @@ import { data as p28 } from "./wedding-catering-menu-guide-pakistan"
 import { data as p29 } from "./what-is-walima-pakistani-wedding-guide"
 import { data as p30 } from "./what-to-wear-to-a-pakistani-wedding-guest-guide"
 import { data as p31 } from "./who-pays-for-what-pakistani-wedding-expenses-guide"
+import { data as p32 } from "./pakistani-bridal-dress-guide"
+import { data as p33 } from "./barat-dress-for-bride"
+import { data as p34 } from "./walima-dress-for-bride"
+import { data as p35 } from "./mehndi-dress-for-bride"
+import { data as p36 } from "./nikkah-dress-for-bride"
+import { data as p37 } from "./wedding-photography-cost-in-lahore"
 
 /** All data-driven content pillars (for sitemap + listings). */
-export const CONTENT_PILLARS: PillarData[] = [p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, p22, p23, p24, p25, p26, p27, p28, p29, p30, p31]
+export const CONTENT_PILLARS: PillarData[] = [p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, p22, p23, p24, p25, p26, p27, p28, p29, p30, p31, p32, p33, p34, p35, p36, p37]

--- a/lib/content/pillars/mehndi-dress-for-bride.ts
+++ b/lib/content/pillars/mehndi-dress-for-bride.ts
@@ -1,0 +1,454 @@
+import type { PillarData } from "@/lib/content/pillar-types"
+
+export const data: PillarData = {
+  "slug": "mehndi-dress-for-bride",
+  "title": "Mehndi Dress for Bride 2026: Colours, Silhouettes & Comfortable Outfit Ideas (Pakistan)",
+  "h1": "Mehndi Dress for the Bride: Colours, Silhouettes & Comfortable Outfit Ideas",
+  "metaDescription": "A Pakistan-specific guide to mehndi outfits for brides: festive yellow, green and multi-colour palettes, comfy silhouettes for dancing, fresh-flower jewellery, fabrics and costs.",
+  "eyebrow": "Bridal Attire Guide",
+  "updatedLabel": "June 2026",
+  "lead": "For a Pakistani mehndi, the bride traditionally wears something festive, colourful and easy to move in — yellow, green, orange or bold multi-colour, accented with gota, mirror or floral work. A lehenga-choli, gharara, sharara or a flowy frock all work, finished with fresh-flower (gajra and genda phool) jewellery rather than heavy gold. Comfort matters most here, because the mehndi is the night you actually dance.",
+  "authorName": "Wedding Wala Editorial Team",
+  "breadcrumb": [
+    {
+      "name": "Home",
+      "href": "/"
+    },
+    {
+      "name": "Blog",
+      "href": "/blog"
+    },
+    {
+      "name": "Mehndi Dress for Bride",
+      "href": "/mehndi-dress-for-bride"
+    }
+  ],
+  "sections": [
+    {
+      "type": "h2",
+      "text": "The mehndi look: festive, colourful and made for dancing"
+    },
+    {
+      "type": "p",
+      "text": "The mehndi (or mayun, in some families) is the most playful function of a Pakistani wedding — flowers, dholki beats, ubtan, and the dance floor. Unlike the heavy, formal barat outfit, the mehndi dress is built around colour, movement and comfort. The bride is on her feet for hours, so the outfit should let her sit cross-legged for the henna ritual, twirl during the dances, and still photograph beautifully under marigold strings. Think vibrant, lightweight and joyful rather than regal and weighed-down. For the wider running order, see our Pakistani wedding events order guide."
+    },
+    {
+      "type": "callout",
+      "text": "The single most useful rule for a mehndi dress: choose it the way you would choose a party outfit you actually want to dance in, not a showpiece you can only pose in. The barat is for grandeur; the mehndi is for joy and movement.",
+      "label": "The mehndi mindset"
+    },
+    {
+      "type": "h2",
+      "text": "Mehndi colours: yellow, green, orange and bold multi-colour"
+    },
+    {
+      "type": "p",
+      "text": "Mehndi is the one function where bright, festive colour is the whole point. Yellow is the most traditional and symbolic shade (tied to the ubtan/haldi ritual and to good fortune), green is a close second, and orange, fuchsia, magenta and multi-colour 'mela' palettes are hugely popular for the energy they bring on camera. Many modern brides now also wear pastels, mint, peach, lilac or even a soft red-orange — colour conventions here are about mood, not rules."
+    },
+    {
+      "type": "table",
+      "caption": "Table A — Mehndi colour palette and the vibe it sends",
+      "headers": [
+        "Colour / palette",
+        "Vibe",
+        "Why it works for mehndi",
+        "Pairs well with"
+      ],
+      "rows": [
+        [
+          "Yellow",
+          "Traditional, auspicious",
+          "Tied to ubtan/haldi; the classic mehndi shade",
+          "Green, orange, white gota"
+        ],
+        [
+          "Green",
+          "Festive, fresh",
+          "Reads beautifully against marigold decor",
+          "Yellow, gold, pink florals"
+        ],
+        [
+          "Orange / rust",
+          "Warm, high-energy",
+          "Photographs vividly under warm lighting",
+          "Fuchsia, gold, green"
+        ],
+        [
+          "Fuchsia / magenta",
+          "Bold, modern",
+          "Pops on the dance floor and in candids",
+          "Yellow, orange, mirror work"
+        ],
+        [
+          "Multi-colour 'mela'",
+          "Playful, maximal",
+          "Captures the carnival mood of mehndi",
+          "Almost anything festive"
+        ],
+        [
+          "Pastels (mint, peach, lilac)",
+          "Soft, contemporary",
+          "On-trend for daytime or minimalist mehndis",
+          "Fresh flowers, light gota"
+        ]
+      ]
+    },
+    {
+      "type": "callout",
+      "text": "Heavy bridal red and deep maroon are conventionally saved for the barat, and ivory/white is associated with the nikah. Wearing them at the mehndi isn't forbidden — it's just less typical — so most brides keep red for the barat and let the mehndi be the colourful, festive outfit. This is etiquette, not a rule.",
+      "label": "Convention, not a rule"
+    },
+    {
+      "type": "h2",
+      "text": "Mehndi silhouettes: lehenga, gharara, sharara or frock"
+    },
+    {
+      "type": "p",
+      "text": "There is no single 'correct' mehndi silhouette — pick the one that lets you move. The lehenga-choli is the most popular and the easiest to dance in; the gharara and sharara are traditional, dramatic and twirl beautifully; the farshi gharara is grand but heavier; and a flowy frock, anarkali or peplum-with-sharara is a comfortable, modern choice. Many brides deliberately go a little lighter on the mehndi than on the barat for exactly this reason."
+    },
+    {
+      "type": "table",
+      "caption": "Table B — Mehndi silhouettes compared",
+      "headers": [
+        "Silhouette",
+        "Movement / comfort",
+        "Vibe",
+        "Best for"
+      ],
+      "rows": [
+        [
+          "Lehenga-choli",
+          "Very easy to dance in",
+          "Festive, versatile",
+          "Most brides; the safe favourite"
+        ],
+        [
+          "Gharara",
+          "Twirls well; flared from the knee",
+          "Traditional, dramatic",
+          "Brides who want a classic, retro look"
+        ],
+        [
+          "Sharara",
+          "Free-flowing, very comfortable",
+          "Festive, flowing",
+          "Dancing and long functions"
+        ],
+        [
+          "Farshi gharara",
+          "Grand but heavier; needs handling",
+          "Regal, vintage",
+          "Statement mehndi; less floor-time dancing"
+        ],
+        [
+          "Frock / anarkali",
+          "Light and breezy",
+          "Soft, modern",
+          "Daytime or minimalist mehndis"
+        ],
+        [
+          "Peplum + sharara / ghagra",
+          "Comfortable, structured top",
+          "Contemporary fusion",
+          "Brides wanting a current, fresh look"
+        ]
+      ]
+    },
+    {
+      "type": "h3",
+      "text": "Lehenga-choli"
+    },
+    {
+      "type": "p",
+      "text": "The lehenga-choli is the default mehndi choice for good reason — the separate flared skirt and fitted blouse give you a festive shape that still moves freely on the dance floor. Keep the skirt mid-weight (heavy cancan and dense embroidery look stunning but tire you out) so you can dance through the dholki numbers."
+    },
+    {
+      "type": "h3",
+      "text": "Gharara & sharara"
+    },
+    {
+      "type": "p",
+      "text": "Ghararas (flared sharply from the knee) and shararas (flared gently from the waist) are deeply traditional and especially photogenic in motion. The sharara is often the most comfortable option of all for a long mehndi, while the gharara delivers a more dramatic, retro silhouette that twirls beautifully during the dances."
+    },
+    {
+      "type": "h3",
+      "text": "Frock, anarkali & peplum looks"
+    },
+    {
+      "type": "p",
+      "text": "For a lighter, more contemporary mehndi, a flowy frock, a floor-length anarkali, or a peplum top paired with a sharara or ghagra keeps things breezy and comfortable. These suit daytime mehndis, smaller home functions, and brides who simply prefer freedom of movement over volume."
+    },
+    {
+      "type": "h2",
+      "text": "Comfort & movement: dressing for the dholki and the dance floor"
+    },
+    {
+      "type": "p",
+      "text": "The mehndi is the function where you'll dance the most, so comfort is a design decision, not an afterthought. Prioritise breathable fabric, a manageable skirt weight, and a securely-fitted blouse. A few practical pointers brides consistently wish they'd known:"
+    },
+    {
+      "type": "ul",
+      "items": [
+        "Keep total outfit weight moderate — gota, mirror and thread work are festive and far lighter than dense zardozi or kora work.",
+        "Choose a dupatta you can pin securely or drape hands-free, so it doesn't slip mid-dance.",
+        "Wear comfortable footwear — khussa, kolhapuri or low block heels beat sky-high heels for a function spent on your feet.",
+        "Make sure the blouse and skirt waist allow you to sit cross-legged for the henna application.",
+        "Pick a fabric that breathes; mehndis often run warm with crowds, lights and dancing.",
+        "Do a quick 'dance test' at the final fitting — twirl, sit and raise your arms to check nothing pulls or pinches."
+      ]
+    },
+    {
+      "type": "h2",
+      "text": "Fresh-flower jewellery: gajra, genda phool and floral sets"
+    },
+    {
+      "type": "p",
+      "text": "The defining accessory of a Pakistani mehndi is fresh-flower jewellery rather than heavy gold. Gajra (jasmine garlands) on the wrists and in the hair, genda phool (marigold) sets, and floral haar, earrings, maang tikka, nath and haath phool are all classic. Floral jewellery is light, fragrant, photogenic and inexpensive — which is exactly why it suits a night of dancing. Many brides save their heavier kundan, polki or gold sets for the barat and walima."
+    },
+    {
+      "type": "table",
+      "caption": "Table C — Mehndi jewellery: fresh-flower vs traditional",
+      "headers": [
+        "Jewellery type",
+        "Weight",
+        "Cost band*",
+        "Best for"
+      ],
+      "rows": [
+        [
+          "Fresh-flower (gajra, genda phool, floral sets)",
+          "Very light",
+          "Low",
+          "The classic, comfortable mehndi look"
+        ],
+        [
+          "Artificial / faux floral",
+          "Light",
+          "Low",
+          "Lasts longer than fresh; reusable for photos"
+        ],
+        [
+          "Light kundan / silver / juttis-style",
+          "Light–medium",
+          "Mid",
+          "A semi-formal mehndi or mixed look"
+        ],
+        [
+          "Heavy gold / polki sets",
+          "Heavy",
+          "High",
+          "Usually saved for barat/walima, not mehndi"
+        ]
+      ]
+    },
+    {
+      "type": "h2",
+      "text": "Fabrics for a mehndi outfit"
+    },
+    {
+      "type": "p",
+      "text": "Because the mehndi is about movement, lighter and more breathable fabrics generally win. Organza, net, chiffon and georgette flow and twirl well; raw silk and cotton-silk add a little structure without too much weight; while heavily embellished velvet or jamawar — gorgeous as they are — are better suited to the barat than to a night of dancing. The festive embellishments to look for here are gota, mirror (shisha), thread and light dabka rather than dense, heavy work."
+    },
+    {
+      "type": "table",
+      "caption": "Table D — Mehndi fabrics by weight and feel",
+      "headers": [
+        "Fabric",
+        "Weight",
+        "Feel / movement",
+        "Note"
+      ],
+      "rows": [
+        [
+          "Organza",
+          "Light",
+          "Crisp, voluminous, twirls well",
+          "Very on-trend for mehndi"
+        ],
+        [
+          "Net",
+          "Light",
+          "Flowy, festive",
+          "Common base for gota/mirror work"
+        ],
+        [
+          "Chiffon / georgette",
+          "Light",
+          "Soft, fluid, breathable",
+          "Great for ghararas and frocks"
+        ],
+        [
+          "Raw silk / cotton-silk",
+          "Light–medium",
+          "Structured but comfortable",
+          "Holds shape; daytime-friendly"
+        ],
+        [
+          "Velvet / jamawar",
+          "Heavy",
+          "Grand but warm",
+          "Better for barat than dancing"
+        ]
+      ]
+    },
+    {
+      "type": "h2",
+      "text": "Designers & where to look for mehndi outfits"
+    },
+    {
+      "type": "p",
+      "text": "Pakistani designers and bridal houses widely known for festive, colourful mehndi-style wear include Ali Xeeshan and Nomi Ansari (celebrated for vivid, playful colour), Maria B, Zainab Chottani, Elan, Zara Shahjahan, Sania Maskatiya and Suffuse by Sana Yasir, while Kashee's is popular for embellished ready-to-wear and rentals. Beyond named designers, busy bridal markets — Liberty and Anarkali in Lahore, Tariq Road and Zainab Market in Karachi — and local boutiques offer custom-stitch and off-the-rack mehndi outfits across every budget. Browse vendors near you in our bridal-wear category."
+    },
+    {
+      "type": "callout",
+      "text": "Don't fixate on a famous label for the mehndi. Because the mehndi outfit is festive rather than the wedding's formal centrepiece, many brides spend less here than on the barat — a well-stitched local-boutique or market piece in the right colour, with fresh-flower jewellery, often photographs just as joyfully as a designer one.",
+      "label": "Budget-smart tip"
+    },
+    {
+      "type": "h2",
+      "text": "Buy, rent or custom-stitch — and indicative cost"
+    },
+    {
+      "type": "p",
+      "text": "There are three main routes for a mehndi outfit: custom-stitch from a boutique or designer for an exact fit, buy ready-to-wear for speed, or rent for a single-use, budget-friendly option. Because mehndi wear is typically lighter and less embellished than barat wear, it usually sits in a more affordable band overall. The guidance below is qualitative (High / Mid / Low) drawn from third-party retail sources — these are not Wedding Wala quotes, and actual prices vary widely with fabric, embellishment, designer and city."
+    },
+    {
+      "type": "table",
+      "caption": "Table E — Buy vs rent vs custom-stitch (cost bands indicative only)",
+      "headers": [
+        "Option",
+        "Indicative cost band*",
+        "Lead time",
+        "Best for"
+      ],
+      "rows": [
+        [
+          "Custom-stitch / designer",
+          "Mid–High (varies widely)",
+          "4–8 weeks; book earlier in peak season",
+          "Brides wanting an exact fit and colour"
+        ],
+        [
+          "Ready-to-wear (minor alteration)",
+          "Low–Mid",
+          "1–3 weeks",
+          "Faster turnaround, standard fit"
+        ],
+        [
+          "Rental",
+          "Typically a fraction of buying",
+          "Days–weeks",
+          "Single-use, budget-conscious brides"
+        ]
+      ]
+    },
+    {
+      "type": "callout",
+      "text": "The cost bands here are indicative only, drawn from third-party retail and designer sources — they are not verified Wedding Wala prices. Mehndi wear generally costs less than barat wear, and rental is usually a fraction of buying. Always confirm current pricing directly with the vendor, since it depends on fabric, embellishment, designer and city.",
+      "label": "Honesty note on pricing"
+    },
+    {
+      "type": "h2",
+      "text": "When to order your mehndi outfit (timeline)"
+    },
+    {
+      "type": "p",
+      "text": "A custom-stitched mehndi outfit typically needs around 4–8 weeks, while ready-to-wear with minor alterations runs roughly 1–3 weeks. A useful Pakistani planning point: for the November–February peak wedding season, start 3–4 months ahead, because the best tailors, boutiques and embellishers fill up fast. Plan your fresh-flower jewellery to be picked up the day of — or arrange artificial florals if your function runs long or starts late. For the full event, see our guide on how to plan a mehndi function."
+    },
+    {
+      "type": "table",
+      "caption": "Mehndi outfit ordering timeline",
+      "headers": [
+        "Route",
+        "Stitching / prep time",
+        "When to start"
+      ],
+      "rows": [
+        [
+          "Custom-stitch / designer",
+          "4–8 weeks",
+          "3–4 months before (especially Nov–Feb peak)"
+        ],
+        [
+          "Ready-to-wear + alteration",
+          "1–3 weeks",
+          "4–6 weeks before"
+        ],
+        [
+          "Rental",
+          "Days–weeks",
+          "3–4 weeks before"
+        ]
+      ]
+    },
+    {
+      "type": "h2",
+      "text": "Where to find mehndi outfits & vendors in your city"
+    },
+    {
+      "type": "p",
+      "text": "Browse bridal and mehndi-wear vendors on Wedding Wala, then line up your makeup artist for the festive, dewy mehndi look that complements bright colour and fresh flowers. Start with the bridal-wear category for your city, book a bridal makeup artist early, and coordinate your outfit colour with the mehndi decor in advance."
+    }
+  ],
+  "faqs": [
+    {
+      "question": "What should a Pakistani bride wear on her mehndi?",
+      "answer": "The mehndi is festive and colourful, so brides traditionally wear bright shades — yellow, green, orange or bold multi-colour — in a lehenga-choli, gharara, sharara or flowy frock with gota, mirror or floral work. The look is finished with fresh-flower jewellery like gajra and genda phool, and prioritises comfort because the mehndi is the function where you dance the most."
+    },
+    {
+      "question": "What colour should a bride wear on her mehndi?",
+      "answer": "Yellow is the most traditional and auspicious mehndi colour (tied to the ubtan/haldi ritual), with green a close second. Orange, fuchsia, magenta and multi-colour 'mela' palettes are also very popular, and many modern brides now wear pastels like mint, peach or lilac. By convention, heavy bridal red is saved for the barat and white for the nikah, leaving the mehndi as the bright, festive outfit."
+    },
+    {
+      "question": "Can a bride wear red on her mehndi?",
+      "answer": "She can, but it's less typical. Deep bridal red and maroon are conventionally associated with the barat, so most brides keep red for that function and choose yellow, green, orange or multi-colour for the mehndi instead. This is etiquette rather than a strict rule, and a soft red-orange or rust can work well on a mehndi."
+    },
+    {
+      "question": "What is the most comfortable outfit for a mehndi?",
+      "answer": "A sharara or a lehenga-choli in a light fabric like organza, net, chiffon or georgette is usually the most comfortable, because both move freely on the dance floor. Keep the skirt weight moderate, choose a securely-fitted blouse, pin the dupatta hands-free, and wear flat khussa or low block heels — the mehndi is the function you dance through, so comfort matters most."
+    },
+    {
+      "question": "What jewellery do brides wear on their mehndi?",
+      "answer": "Fresh-flower jewellery is the classic mehndi accessory — gajra (jasmine) on the wrists and hair, genda phool (marigold) sets, and floral haar, earrings, maang tikka and haath phool. It's light, fragrant, photogenic and inexpensive, which suits a night of dancing. Heavy gold, kundan or polki sets are usually saved for the barat and walima instead."
+    },
+    {
+      "question": "Lehenga, gharara or sharara — which is best for a mehndi?",
+      "answer": "All three work; it comes down to movement and style. A lehenga-choli is the versatile favourite and very easy to dance in, a sharara is often the most comfortable for a long function, and a gharara gives a more dramatic, retro silhouette that twirls beautifully. A flowy frock or peplum-with-sharara is a lighter, modern alternative."
+    },
+    {
+      "question": "How much does a mehndi dress cost in Pakistan?",
+      "answer": "Mehndi wear generally costs less than barat wear because it's lighter and less embellished. As indicative qualitative bands, custom-stitch or designer pieces fall in a Mid–High range, ready-to-wear in Low–Mid, and rental is typically a fraction of buying. These are not Wedding Wala quotes — actual prices vary widely with fabric, embellishment, designer and city, so confirm with the vendor."
+    },
+    {
+      "question": "When should I order my mehndi outfit?",
+      "answer": "A custom-stitched mehndi outfit usually takes around 4–8 weeks, and ready-to-wear with minor alterations roughly 1–3 weeks. For the November–February peak wedding season, start 3–4 months ahead, since the best tailors, boutiques and embellishers fill up quickly. Arrange fresh-flower jewellery for the day itself, or opt for artificial florals if the function runs late."
+    }
+  ],
+  "internalLinks": [
+    {
+      "label": "Pakistani bridal dress guide (hub)",
+      "href": "/pakistani-bridal-dress-guide"
+    },
+    {
+      "label": "How to plan a mehndi function",
+      "href": "/how-to-plan-a-mehndi-function"
+    },
+    {
+      "label": "Nikkah dress for the bride",
+      "href": "/nikkah-dress-for-bride"
+    },
+    {
+      "label": "Find bridal & mehndi-wear vendors",
+      "href": "/bridal-wear"
+    },
+    {
+      "label": "Book a bridal makeup artist",
+      "href": "/bridal-makeup-artists"
+    },
+    {
+      "label": "Pakistani wedding events order",
+      "href": "/pakistani-wedding-events-order"
+    }
+  ],
+  "methodologyNote": "Compiled by the Wedding Wala Editorial Team. Mehndi attire conventions (festive yellow/green/multi-colour palettes; lehenga, gharara, sharara, farshi gharara and frock silhouettes; fresh-flower gajra and genda phool jewellery) are synthesised across multiple Pakistani and South Asian bridal retail and designer references, and reflect widely-observed etiquette rather than fixed rules. Designer names are listed as well-known houses associated with festive bridal wear, not endorsements, and no prices are attributed to them. Cost figures are indicative qualitative bands (High/Mid/Low) from third parties, not Wedding Wala quotes — confirm current pricing with the vendor. Colour and event conventions are stated as etiquette, not strict rules."
+}

--- a/lib/content/pillars/nikkah-dress-for-bride.ts
+++ b/lib/content/pillars/nikkah-dress-for-bride.ts
@@ -1,0 +1,413 @@
+import type { PillarData } from "@/lib/content/pillar-types"
+
+export const data: PillarData = {
+  "slug": "nikkah-dress-for-bride",
+  "title": "Nikkah Dress for Bride 2026: Colours, Modesty & What Pakistani Brides Wear",
+  "h1": "Nikkah Dress for Bride: Colours, Silhouettes & What to Wear for the Nikah",
+  "metaDescription": "A neutral, Pakistan-specific guide to the bride's nikkah dress: white, ivory and pastel colours, modest silhouettes, fabrics, how it differs from barat and walima, and costs.",
+  "eyebrow": "Bridal Attire Guide",
+  "updatedLabel": "June 2026",
+  "lead": "For the Nikah, most Pakistani brides choose an understated, elegant and modest look — white, ivory, off-white, mint or a soft pastel — rather than the heavy bridal red kept for the Barat. A graceful angarkha, maxi/gown, anarkali or a lightly worked lehenga with full sleeves and a dupatta over the head is the classic choice for this religious ceremony. This guide covers colours, modesty, silhouettes, fabrics and how the nikkah dress differs from the barat and walima looks.",
+  "authorName": "Wedding Wala Editorial Team",
+  "breadcrumb": [
+    {
+      "name": "Home",
+      "href": "/"
+    },
+    {
+      "name": "Blog",
+      "href": "/blog"
+    },
+    {
+      "name": "Nikkah Dress for Bride",
+      "href": "/nikkah-dress-for-bride"
+    }
+  ],
+  "sections": [
+    {
+      "type": "h2",
+      "text": "What does a bride wear for her Nikah?"
+    },
+    {
+      "type": "p",
+      "text": "The Nikah is the religious heart of a Pakistani wedding — the moment the marriage contract is signed — so the bride's outfit is deliberately understated, elegant and modest rather than maximal. The classic palette is white, ivory, off-white, champagne, mint or a soft pastel, in a silhouette that covers well: an angarkha, an anarkali, a maxi or gown, or a lightly embellished lehenga, almost always with full or three-quarter sleeves and a dupatta drawn over the head. The mood is grace and restraint, leaving the heavy bridal red and dense embroidery for the Barat. See where the Nikah sits in the day in our Pakistani wedding events order guide."
+    },
+    {
+      "type": "callout",
+      "text": "Two load-bearing conventions: the Nikah leans modest (full sleeves, higher neckline, a dupatta over the head are the norm) and light on colour (white, ivory and pastels rather than bridal red). Both are etiquette and family preference, not strict religious rules — many brides adapt them, and Nikah-and-Barat-on-the-same-day brides often pick one outfit that bridges both.",
+      "label": "The Nikah difference"
+    },
+    {
+      "type": "h2",
+      "text": "Appropriate colours for the nikkah dress"
+    },
+    {
+      "type": "p",
+      "text": "Colour is the single most-searched question for the nikkah dress, and the short answer is: keep it soft. White, ivory, off-white and champagne are the traditional anchors, with mint, powder blue, blush pink, lilac, sage and dusty rose all popular modern choices. Deep bridal red and heavy maroon are conventionally reserved for the Barat, while bold gold-on-red is generally felt to be too much for the religious ceremony. Some families do choose a richer pastel or a pale gold for the Nikah — there is room for personal taste."
+    },
+    {
+      "type": "table",
+      "caption": "Table A — Nikkah colours, the message they send, and notes",
+      "headers": [
+        "Colour family",
+        "Reads as",
+        "Note"
+      ],
+      "rows": [
+        [
+          "White / ivory / off-white",
+          "Purity, calm, classic",
+          "The most traditional Nikah choice; never out of place"
+        ],
+        [
+          "Champagne / pale gold",
+          "Soft luxe, warm",
+          "Flatters most skin tones; photographs well in daylight"
+        ],
+        [
+          "Mint / sage / powder blue",
+          "Fresh, modern",
+          "Popular for day-time and spring Nikahs"
+        ],
+        [
+          "Blush / dusty rose / lilac",
+          "Romantic, feminine",
+          "Pastel pinks and mauves are a current favourite"
+        ],
+        [
+          "Deep red / heavy maroon",
+          "Bridal, festive",
+          "Conventionally kept for the Barat, not the Nikah"
+        ]
+      ]
+    },
+    {
+      "type": "h2",
+      "text": "Modesty: sleeves, neckline and dupatta"
+    },
+    {
+      "type": "p",
+      "text": "Because the Nikah is the religious ceremony, most brides choose a more covered silhouette than they might for the Barat or Walima. In practice this means full or three-quarter sleeves, a higher or modest neckline, and a dupatta or shawl draped over the head — often used for the moment the bride signs the nikahnama. How modest the look is depends heavily on family and region: more conservative families lean fully covered, while others are comfortable with a lighter dupatta over the shoulders. None of this is a fixed rule; it is etiquette, and brides should follow what feels right for their family. For the ceremony itself, see our nikah process in Pakistan explainer."
+    },
+    {
+      "type": "h2",
+      "text": "Silhouettes for the nikkah dress"
+    },
+    {
+      "type": "p",
+      "text": "Several silhouettes suit the elegant, modest brief of the Nikah. The angarkha — with its cross-over front and flowing panels — is a graceful, heritage-leaning choice; the anarkali (a long, fitted-to-flared frock) is flattering and timeless; the maxi or gown reads contemporary and refined; and a lightly worked lehenga or sharara gives a fuller, festive shape without the weight of a Barat lehenga. The gharara and farshi gharara are richer, more traditional options some brides prefer."
+    },
+    {
+      "type": "table",
+      "caption": "Table B — Nikkah silhouettes compared",
+      "headers": [
+        "Silhouette",
+        "Shape",
+        "Mood",
+        "Best for"
+      ],
+      "rows": [
+        [
+          "Angarkha",
+          "Cross-over front, flowing panels",
+          "Heritage, graceful",
+          "Brides wanting a soft, traditional look"
+        ],
+        [
+          "Anarkali",
+          "Fitted bodice flaring to a long frock",
+          "Timeless, flattering",
+          "Most body types; easy to keep modest"
+        ],
+        [
+          "Maxi / gown",
+          "Long, fitted or A-line column",
+          "Modern, minimal",
+          "Contemporary, understated Nikahs"
+        ],
+        [
+          "Lehenga (light)",
+          "Blouse + flared skirt + dupatta",
+          "Festive but soft",
+          "Brides wanting some volume without Barat weight"
+        ],
+        [
+          "Gharara / sharara / farshi gharara",
+          "Flared trousers / pleated from knee",
+          "Regal, traditional",
+          "Heritage-leaning and Urdu-speaking families"
+        ]
+      ]
+    },
+    {
+      "type": "h2",
+      "text": "How the nikkah dress differs from barat and walima"
+    },
+    {
+      "type": "p",
+      "text": "The three central bridal looks are deliberately different in colour, weight and mood. The Nikah is the lightest and most modest; the Barat is the heaviest and most ceremonial, traditionally in red or maroon; and the Walima is elegant and contemporary, usually in pastels or muted tones. Understanding the contrast helps brides plan a wardrobe that does not repeat itself. Compare with our barat dress for the bride and walima dress for the bride guides."
+    },
+    {
+      "type": "table",
+      "caption": "Table C — Nikah vs Barat vs Walima for the bride",
+      "headers": [
+        "Event",
+        "Typical colour",
+        "Embellishment",
+        "Mood",
+        "Coverage"
+      ],
+      "rows": [
+        [
+          "Nikah",
+          "White, ivory, mint, pastel",
+          "Light to moderate",
+          "Modest, serene, elegant",
+          "Most covered (full sleeves, dupatta on head)"
+        ],
+        [
+          "Barat",
+          "Red, maroon, deep jewel tones",
+          "Heaviest; dense work",
+          "Festive, ceremonial, bridal",
+          "Traditional bridal styling"
+        ],
+        [
+          "Walima",
+          "Pastels, champagne, muted tones",
+          "Refined, moderate",
+          "Polished, contemporary",
+          "Elegant; flexible"
+        ]
+      ]
+    },
+    {
+      "type": "h2",
+      "text": "Fabrics for the nikkah dress"
+    },
+    {
+      "type": "p",
+      "text": "Because the Nikah look is light and graceful, the fabrics tend to flow and catch the light softly rather than sit heavy. Chiffon, organza, net, raw silk, jamawar (in lighter weights), velvet (for winter Nikahs), and tissue or tea-silk are all common. Embroidery is usually moderate — threadwork, light dabka and kora, sequins, pearls or tilla — rather than the dense, structural embellishment of a Barat lehenga. Fabric weight should also follow the season and time of day."
+    },
+    {
+      "type": "table",
+      "caption": "Table D — Fabric by season and effect",
+      "headers": [
+        "Fabric",
+        "Weight",
+        "Best season",
+        "Effect"
+      ],
+      "rows": [
+        [
+          "Chiffon / organza",
+          "Light",
+          "Summer, daytime",
+          "Airy, soft, flowing"
+        ],
+        [
+          "Net",
+          "Light–medium",
+          "All seasons",
+          "Holds light embellishment well"
+        ],
+        [
+          "Raw silk / tissue",
+          "Light–medium",
+          "All / evening",
+          "Subtle sheen, structured drape"
+        ],
+        [
+          "Jamawar (light)",
+          "Medium",
+          "Autumn–winter",
+          "Woven motifs, regal but soft"
+        ],
+        [
+          "Velvet",
+          "Heavy",
+          "Winter, evening",
+          "Warm, grand; for cooler-month Nikahs"
+        ]
+      ]
+    },
+    {
+      "type": "h2",
+      "text": "Designers and where to look"
+    },
+    {
+      "type": "p",
+      "text": "Pakistan's leading bridal houses all offer elegant Nikah and pastel pieces alongside their heavier Barat couture. Names brides commonly look at include Kashee's, Maria B, HSY, Nomi Ansari, Elan, Zara Shahjahan, Ali Xeeshan, Suffuse by Sana Yasir, Zainab Chottani, Sania Maskatiya and Faraz Manan — ranging from heavily worked couture to softer, ready-to-wear pastels. Many brides also use a trusted local boutique or master tailor for a custom Nikah outfit at a friendlier price. Browse bridal-wear vendors on Wedding Wala to compare options in your city."
+    },
+    {
+      "type": "callout",
+      "text": "Designer naming here is for orientation only. We do not quote prices for any designer — couture pricing varies enormously with fabric, embroidery density, customisation and collection. Always confirm current pricing directly with the designer or boutique.",
+      "label": "On designers"
+    },
+    {
+      "type": "h2",
+      "text": "Indicative cost: buy vs rent vs custom-stitch"
+    },
+    {
+      "type": "p",
+      "text": "There are three main routes for the nikkah dress: a custom-stitched piece from a boutique or tailor for an exact fit, a ready-to-wear or designer outfit for speed, or a rental for a single-use, budget-friendly option. Because the Nikah look is lighter than the Barat, it can often cost less than the main bridal lehenga — but this varies widely. The cost guidance below is qualitative (High / Mid / Low bands) drawn from third-party bridal-retail sources — these are not Wedding Wala quotes, and actual prices depend on fabric, embroidery, designer and city."
+    },
+    {
+      "type": "table",
+      "caption": "Table E — Buy vs rent vs custom (cost bands indicative only)",
+      "headers": [
+        "Option",
+        "Indicative cost band*",
+        "Lead time",
+        "Best for"
+      ],
+      "rows": [
+        [
+          "Designer couture",
+          "High (varies widely)",
+          "Book 3–6 months ahead",
+          "Brides wanting a statement Nikah look and keepsake"
+        ],
+        [
+          "Custom-stitch (boutique / tailor)",
+          "Mid",
+          "4–8 weeks",
+          "Personalised fit at a friendlier price"
+        ],
+        [
+          "Ready-to-wear (minor alteration)",
+          "Mid",
+          "Days–weeks",
+          "Standard fit, faster turnaround"
+        ],
+        [
+          "Rental",
+          "Typically a fraction of buying",
+          "Days–weeks",
+          "Single-use, budget-conscious brides"
+        ]
+      ]
+    },
+    {
+      "type": "callout",
+      "text": "The cost bands here are indicative only, drawn from third-party bridal-retail and designer sources — they are not verified Wedding Wala prices. Rental is usually a fraction of buying. Always confirm current pricing directly with the vendor, since it depends on fabric, embroidery, designer and city.",
+      "label": "Honesty note on pricing"
+    },
+    {
+      "type": "h2",
+      "text": "When to finalise your nikkah dress (timeline)"
+    },
+    {
+      "type": "p",
+      "text": "A custom-stitched nikkah dress typically needs around 4–8 weeks once the design is locked, while designer couture is best booked 3–6 months ahead. A useful Pakistani planning point: for the November–February peak wedding season, the best boutiques, designers and master tailors fill up fast, so finalise the design early and leave room for at least one fitting. If your Nikah and Barat fall on the same day, decide early whether you want one outfit that bridges both or a quick change between them."
+    },
+    {
+      "type": "table",
+      "caption": "Nikkah dress ordering timeline",
+      "headers": [
+        "Route",
+        "Stitching / prep time",
+        "When to start"
+      ],
+      "rows": [
+        [
+          "Designer couture",
+          "Varies; allow long lead",
+          "3–6 months before (especially Nov–Feb peak)"
+        ],
+        [
+          "Custom-stitch",
+          "4–8 weeks",
+          "2–3 months before"
+        ],
+        [
+          "Ready-to-wear + alteration",
+          "Days–weeks",
+          "3–6 weeks before"
+        ],
+        [
+          "Rental",
+          "Days–weeks",
+          "3–6 weeks before"
+        ]
+      ]
+    },
+    {
+      "type": "h2",
+      "text": "Hair, makeup and styling for the Nikah"
+    },
+    {
+      "type": "p",
+      "text": "The Nikah look is usually soft and natural to match the understated outfit — a dewy, fresh face, a light or no-jhoomar hairstyle, and minimal jewellery (often just earrings and a delicate maang tikka or matha patti). Many brides keep the heavier, fully glam look for the Barat. Booking a skilled artist early matters, especially in peak season — see our guide on how to choose a bridal makeup artist in Pakistan, or browse bridal makeup artists directly."
+    },
+    {
+      "type": "h2",
+      "text": "Where to find your nikkah dress & vendors in your city"
+    },
+    {
+      "type": "p",
+      "text": "Start with the bridal-wear category to compare boutiques, designers and tailors in your city, then line up your makeup artist and photographer for the day. For the full picture of how the Nikah, Barat and Walima looks fit together, see our Pakistani bridal dress guide hub."
+    }
+  ],
+  "faqs": [
+    {
+      "question": "What should a Pakistani bride wear for her Nikah?",
+      "answer": "Most Pakistani brides wear an understated, elegant and modest outfit for the Nikah — typically white, ivory, off-white, mint or a soft pastel — in a silhouette like an angarkha, anarkali, maxi/gown or a lightly worked lehenga. Full or three-quarter sleeves, a modest neckline and a dupatta drawn over the head are the norm, since the Nikah is the religious ceremony. The heavy bridal red is kept for the Barat."
+    },
+    {
+      "question": "What colour should a bride wear for her Nikah?",
+      "answer": "White, ivory, off-white and champagne are the most traditional Nikah colours, with mint, powder blue, blush pink, lilac, sage and dusty rose as popular modern pastels. Deep bridal red and heavy maroon are conventionally reserved for the Barat, so they are usually avoided for the religious ceremony. This is etiquette and family preference rather than a strict rule, so a richer pastel or pale gold is also fine."
+    },
+    {
+      "question": "Can a bride wear white for her Nikah in Pakistan?",
+      "answer": "Yes. White, ivory and off-white are among the most classic and appropriate colours for a Pakistani Nikah, reading as pure, calm and elegant. Unlike some Western contexts where white is saved for one specific event, in Pakistan a white or ivory Nikah outfit is entirely standard and is a popular choice across families."
+    },
+    {
+      "question": "How modest should a nikkah dress be?",
+      "answer": "Because the Nikah is the religious ceremony, most brides choose a more covered look — full or three-quarter sleeves, a modest neckline, and a dupatta or shawl over the head, often for the moment of signing the nikahnama. How conservative the styling is depends on family and region. This is etiquette and personal or family preference rather than a fixed rule, so brides should follow what feels right for them."
+    },
+    {
+      "question": "How is the nikkah dress different from the barat dress?",
+      "answer": "The nikkah dress is light, modest and usually white, ivory or pastel, with moderate embellishment to suit the religious ceremony. The barat dress is the heaviest and most ceremonial bridal look, traditionally in red or maroon with dense embroidery. In short, the Nikah is restrained and serene while the Barat is festive and fully bridal."
+    },
+    {
+      "question": "Which silhouette is best for a nikkah dress?",
+      "answer": "Popular Nikah silhouettes include the angarkha (a graceful cross-over heritage cut), the anarkali (a flattering long frock), a maxi or gown for a modern minimal look, and a lightly worked lehenga or sharara for some festive volume. The gharara and farshi gharara are richer, more traditional options. The right choice depends on your body type, how modest you want the look, and your family's style."
+    },
+    {
+      "question": "Is it better to buy, custom-stitch or rent a nikkah dress?",
+      "answer": "Buy or custom-stitch if you want an exact fit and a keepsake, or designer couture for a statement look (best booked months ahead). Custom-stitching with a boutique or tailor gives a personalised fit at a friendlier price. Rent if it is a single-use, budget-conscious decision, since rental typically costs a fraction of buying. Confirm current pricing with the vendor, as it varies with fabric, embroidery and designer."
+    },
+    {
+      "question": "When should I finalise my nikkah dress?",
+      "answer": "A custom-stitched nikkah dress usually needs around 4–8 weeks once the design is locked, while designer couture is best booked 3–6 months ahead. For the November–February peak wedding season, finalise the design early because the best boutiques, designers and tailors fill up quickly, and leave time for at least one fitting. If your Nikah and Barat are on the same day, decide early whether one outfit will bridge both."
+    }
+  ],
+  "internalLinks": [
+    {
+      "label": "Pakistani bridal dress guide",
+      "href": "/pakistani-bridal-dress-guide"
+    },
+    {
+      "label": "Walima dress for the bride",
+      "href": "/walima-dress-for-bride"
+    },
+    {
+      "label": "Nikah process in Pakistan",
+      "href": "/nikah-process-in-pakistan"
+    },
+    {
+      "label": "Pakistani wedding events order",
+      "href": "/pakistani-wedding-events-order"
+    },
+    {
+      "label": "Find bridal-wear vendors",
+      "href": "/bridal-wear"
+    },
+    {
+      "label": "Book a bridal makeup artist",
+      "href": "/bridal-makeup-artists"
+    }
+  ],
+  "methodologyNote": "Compiled by the Wedding Wala Editorial Team. Guidance on Nikah colours (white, ivory, off-white and pastels), modesty conventions (full sleeves, modest neckline, dupatta over the head), silhouettes (angarkha, anarkali, maxi/gown, lehenga, gharara) and fabrics is synthesised across multiple Pakistani and South Asian bridal-retail and designer references. Designer names are listed for orientation only and we do not quote their prices. Cost figures are indicative qualitative bands (High/Mid/Low) from third parties, not Wedding Wala quotes — confirm current pricing with the vendor. Colour and modesty conventions are stated as etiquette and family preference, not strict religious rules."
+}

--- a/lib/content/pillars/pakistani-bridal-dress-guide.ts
+++ b/lib/content/pillars/pakistani-bridal-dress-guide.ts
@@ -1,0 +1,492 @@
+import type { PillarData } from "@/lib/content/pillar-types"
+
+export const data: PillarData = {
+  "slug": "pakistani-bridal-dress-guide",
+  "title": "Pakistani Bridal Dress Guide 2026: What the Bride Wears at Every Event",
+  "h1": "Pakistani Bridal Dress Guide: What to Wear at Every Wedding Event",
+  "metaDescription": "A neutral, Pakistan-specific bridal dress guide: what the bride wears at Mayun, Mehndi, Nikah, Barat and Walima, plus silhouettes, colours, fabrics and indicative costs.",
+  "eyebrow": "Bridal Attire Guide",
+  "updatedLabel": "June 2026",
+  "lead": "The Pakistani bride changes her look across several functions: a festive yellow or floral outfit for Mehndi, an understated white or pastel piece for the Nikah, a heavily embellished red or maroon lehenga for the Barat, and an elegant pastel gown or sharara for the Walima. Most brides build the look around the Barat first and dress the other events lighter. This guide covers what to wear at each event, the main silhouettes, colours, fabrics and how to budget and time your order.",
+  "authorName": "Wedding Wala Editorial Team",
+  "breadcrumb": [
+    {
+      "name": "Home",
+      "href": "/"
+    },
+    {
+      "name": "Blog",
+      "href": "/blog"
+    },
+    {
+      "name": "Bridal Dress Guide",
+      "href": "/pakistani-bridal-dress-guide"
+    }
+  ],
+  "sections": [
+    {
+      "type": "h2",
+      "text": "What the bride wears at each wedding event"
+    },
+    {
+      "type": "p",
+      "text": "A Pakistani wedding unfolds across several functions, and the bride's outfit shifts with the mood and formality of each. The Mayun and Mehndi are festive and informal; the Nikah is the solemn, religious core; the Barat is the most ceremonial; and the Walima reception leans elegant and refined. The look peaks at the Barat, so most brides plan that outfit first and dress the surrounding events lighter. See how the functions sequence in our Pakistani wedding events order guide."
+    },
+    {
+      "type": "table",
+      "caption": "Table A — What the bride wears per event",
+      "headers": [
+        "Event",
+        "Typical outfit",
+        "Colour mood",
+        "Embellishment level",
+        "Spoke guide"
+      ],
+      "rows": [
+        [
+          "Mayun",
+          "Light gharara or kurta + simple jewellery",
+          "Yellow, ubtan-friendly tones",
+          "Minimal",
+          "See Mehndi guide"
+        ],
+        [
+          "Mehndi",
+          "Lehenga, gharara or sharara",
+          "Yellow, green, floral, multicolour",
+          "Light–medium, festive",
+          "Mehndi dress for bride"
+        ],
+        [
+          "Nikah",
+          "Maxi, anarkali or modest gharara",
+          "White, ivory, soft pastel",
+          "Understated, refined",
+          "Nikkah dress for bride"
+        ],
+        [
+          "Barat",
+          "Heavy lehenga-choli or farshi gharara",
+          "Red, maroon, deep gold",
+          "Maximal, bridal",
+          "Barat dress for bride"
+        ],
+        [
+          "Walima",
+          "Gown, maxi or pastel lehenga",
+          "Pastel, ivory, champagne, powder tones",
+          "Elegant, medium",
+          "Walima dress for bride"
+        ]
+      ]
+    },
+    {
+      "type": "h3",
+      "text": "Mayun & Mehndi"
+    },
+    {
+      "type": "p",
+      "text": "The Mayun and Mehndi are the festive, music-and-dance functions, so the outfit is comfortable, colourful and easy to move in. Yellow is the classic Mayun colour (it pairs with the ubtan ritual), while the Mehndi opens up to green, floral prints, gota-edged ghararas and multicoloured lehengas. A lighter, less restrictive cut matters because the bride is on her feet for the dholki and dances. For the function itself, see our guide on how to plan a Mehndi function."
+    },
+    {
+      "type": "h3",
+      "text": "Nikah"
+    },
+    {
+      "type": "p",
+      "text": "The Nikah is the religious heart of the wedding, so the bride's look stays understated and modest: a maxi, anarkali or simple gharara in white, ivory or a soft pastel, with restrained embellishment and lighter jewellery. Many families pair it with a dupatta draped over the head. Read more about the ceremony in our Nikah process in Pakistan explainer, and outfit specifics in the dedicated Nikkah dress for bride guide."
+    },
+    {
+      "type": "h3",
+      "text": "Barat"
+    },
+    {
+      "type": "p",
+      "text": "The Barat is the bridal outfit's biggest moment — the most photographed and most ceremonial look of the wedding. Traditionally this is a heavily embellished lehenga-choli or farshi gharara in red, maroon or deep gold, dense with zardozi, dabka and stonework, finished with statement jewellery and a long dupatta. Because it carries the most weight and is the most photographed, plan it first and coordinate it with your photographer. See the full Barat dress for bride guide and our Barat traditions explainer."
+    },
+    {
+      "type": "h3",
+      "text": "Walima"
+    },
+    {
+      "type": "p",
+      "text": "The Walima reception, hosted by the groom's family, leans elegant and contemporary. Brides often choose a flowing gown, a maxi or a pastel lehenga in ivory, champagne, powder blue, blush or other soft tones, with refined rather than maximal embellishment. It is a deliberate contrast to the heavy Barat red. See the Walima dress for bride guide and our what is a Walima explainer for context."
+    },
+    {
+      "type": "h2",
+      "text": "Bridal silhouettes explained"
+    },
+    {
+      "type": "p",
+      "text": "Pakistani bridal wear spans several distinct silhouettes. Knowing them helps you brief a designer or tailor precisely and choose the right shape for each event and your frame."
+    },
+    {
+      "type": "table",
+      "caption": "Table B — Bridal silhouette comparison",
+      "headers": [
+        "Silhouette",
+        "Shape",
+        "Best event",
+        "Notes"
+      ],
+      "rows": [
+        [
+          "Lehenga-choli",
+          "Flared skirt + fitted blouse + dupatta",
+          "Barat (and pastel for Walima)",
+          "The classic heavy bridal shape"
+        ],
+        [
+          "Farshi gharara",
+          "Wide floor-trailing flared trousers",
+          "Barat / Nikah",
+          "Regal, heritage Lucknowi style"
+        ],
+        [
+          "Gharara",
+          "Flared from the knee, joined at knee",
+          "Mehndi / Nikah",
+          "Festive and comfortable"
+        ],
+        [
+          "Sharara",
+          "Flared from the waist, fuller leg",
+          "Mehndi / Nikah",
+          "Easy movement, twirl-friendly"
+        ],
+        [
+          "Anarkali",
+          "Long fitted-bodice frock that flares out",
+          "Nikah / Mehndi",
+          "Flattering, graceful"
+        ],
+        [
+          "Maxi / gown",
+          "Long fitted or flowing one-piece",
+          "Walima / Nikah",
+          "Modern, elegant"
+        ]
+      ]
+    },
+    {
+      "type": "h2",
+      "text": "Choosing your colour by event"
+    },
+    {
+      "type": "p",
+      "text": "Colour is the fastest way to signal which event you are dressing for, and most Pakistani brides follow a recognisable arc: festive at the Mehndi, soft at the Nikah, deep and bridal at the Barat, and elegant pastel at the Walima. Your complexion and the season also matter — warm skin tones tend to flatter gold, rust, coral and earthy greens, while cooler tones carry maroon, plum, emerald and powder pastels well."
+    },
+    {
+      "type": "table",
+      "caption": "Table C — Colour mood by event",
+      "headers": [
+        "Event",
+        "Conventional palette",
+        "Why"
+      ],
+      "rows": [
+        [
+          "Mayun",
+          "Yellow, soft warm tones",
+          "Pairs with the ubtan ritual; festive"
+        ],
+        [
+          "Mehndi",
+          "Yellow, green, floral, multicolour",
+          "Festive, photogenic against henna and flowers"
+        ],
+        [
+          "Nikah",
+          "White, ivory, blush, mint, lilac",
+          "Understated and modest for the religious ceremony"
+        ],
+        [
+          "Barat",
+          "Red, maroon, deep gold, rust",
+          "The traditional, ceremonial bridal colour"
+        ],
+        [
+          "Walima",
+          "Pastel, champagne, ivory, powder tones",
+          "Elegant contrast to the heavy Barat red"
+        ]
+      ]
+    },
+    {
+      "type": "callout",
+      "text": "Red and maroon at the Barat is the strong Pakistani convention, but it is etiquette and taste — not a rule. Plenty of brides now wear deep pinks, rusts, emeralds or even pastel lehengas for the Barat, and white or ivory for the Nikah is entirely standard. Treat these palettes as a starting point, not a restriction.",
+      "label": "Convention, not a rule"
+    },
+    {
+      "type": "h2",
+      "text": "Fabrics & embellishment"
+    },
+    {
+      "type": "p",
+      "text": "Bridal wear is defined as much by its fabric base and its handwork as by its silhouette. Fabric weight should follow the season and event — lighter weaves like raw silk, organza and net suit summer, daytime and lighter functions, while heavier velvet, jamawar and brocade carry winter and the grand Barat look. The embroidery vocabulary you will hear in the Pakistani market includes zardozi (metallic goldwork), dabka (coiled wire), gota (ribbon appliqué), resham (silk thread), kora, naqshi, sequins and stone or crystal work."
+    },
+    {
+      "type": "table",
+      "caption": "Table D — Fabric by season & event",
+      "headers": [
+        "Fabric",
+        "Weight",
+        "Best season / event",
+        "Note"
+      ],
+      "rows": [
+        [
+          "Raw silk",
+          "Light–medium",
+          "All seasons; Nikah, Walima",
+          "Versatile, holds embroidery well"
+        ],
+        [
+          "Organza / net",
+          "Light",
+          "Summer; Mehndi, Walima",
+          "Airy, layered, modern"
+        ],
+        [
+          "Chiffon",
+          "Light",
+          "Summer, daytime",
+          "Flowing, soft drape"
+        ],
+        [
+          "Jamawar",
+          "Medium–heavy",
+          "Winter; Barat",
+          "Woven motifs, regal"
+        ],
+        [
+          "Velvet",
+          "Heavy",
+          "Winter, evening; Barat",
+          "Grand, warm, dramatic"
+        ],
+        [
+          "Brocade",
+          "Heavy",
+          "Winter; Barat",
+          "Dense, maximal embellishment"
+        ]
+      ]
+    },
+    {
+      "type": "h2",
+      "text": "Top Pakistani bridal designers"
+    },
+    {
+      "type": "p",
+      "text": "Pakistan has a deep bench of established bridal couture houses, each with a recognisable signature. Use these names as a reference for style direction rather than price — designer cost varies enormously with fabric, embroidery density and customisation, so always confirm current pricing directly."
+    },
+    {
+      "type": "ul",
+      "items": [
+        "Kashee's — known for very heavily embellished, maximal bridal looks and a signature makeup-and-outfit aesthetic.",
+        "HSY — luxury couture with structured, dramatic silhouettes.",
+        "Maria B — accessible-to-premium bridals across a wide range of styles.",
+        "Nomi Ansari — colourful, vibrant and Mehndi-friendly palettes.",
+        "Elan — refined, regal and intricately worked bridal couture.",
+        "Zara Shahjahan — classic, heritage-inspired aesthetics.",
+        "Ali Xeeshan — bold, theatrical and statement bridal design.",
+        "Suffuse by Sana Yasir, Zainab Chottani, Sania Maskatiya and Faraz Manan — further established couture houses spanning regal, contemporary and pastel-led signatures."
+      ]
+    },
+    {
+      "type": "callout",
+      "text": "Naming a designer here is not an endorsement or a price quote — these are style references only. Designer bridal prices vary widely with fabric, embroidery, customisation and season, and we do not publish their rates. Confirm current pricing and lead times directly with the design house or boutique.",
+      "label": "Designers are style references, not quotes"
+    },
+    {
+      "type": "h2",
+      "text": "Buy ready-to-wear vs custom-stitch vs rent"
+    },
+    {
+      "type": "p",
+      "text": "There are three main routes to a bridal outfit: a bespoke custom piece for an exact fit and a keepsake, a ready-to-wear bridal with minor alterations for speed, or a rental for a single-use, budget-conscious option (more common for Mehndi or Walima than for the Barat). The cost guidance below is qualitative — High, Mid and Low bands — drawn from third-party Pakistani bridal retail sources. These are not Wedding Wala quotes, and actual prices vary widely with fabric, embroidery density, designer and city."
+    },
+    {
+      "type": "table",
+      "caption": "Table E — Buy vs custom-stitch vs rent (cost bands indicative only)",
+      "headers": [
+        "Option",
+        "Indicative cost band*",
+        "Lead time",
+        "Best for"
+      ],
+      "rows": [
+        [
+          "Custom / bespoke designer",
+          "High (varies widely)",
+          "8–16 weeks; book 4–8 months ahead",
+          "The Barat outfit; exact fit and a keepsake"
+        ],
+        [
+          "Ready-to-wear (minor alteration)",
+          "Mid",
+          "4–8 weeks",
+          "Standard fit, faster turnaround, lighter events"
+        ],
+        [
+          "Rental",
+          "Low (a fraction of buying)",
+          "Days–weeks",
+          "Single-use Mehndi or Walima looks, budget"
+        ]
+      ]
+    },
+    {
+      "type": "callout",
+      "text": "The cost bands here are indicative qualitative ranges only, synthesised from third-party Pakistani bridal retail sources — they are not verified Wedding Wala prices. Rental is usually a fraction of buying. Always confirm current pricing directly with the designer or boutique, since it depends on fabric, embroidery, customisation, designer and city.",
+      "label": "Honesty note on pricing"
+    },
+    {
+      "type": "h2",
+      "text": "When to order your bridal outfit (timeline)"
+    },
+    {
+      "type": "p",
+      "text": "A bespoke bridal — especially the heavily worked Barat lehenga — typically needs roughly 8–16 weeks to design, stitch and embroider, while ready-to-wear with alterations runs about 4–8 weeks. The key Pakistani planning point: book 4–8 months ahead for the November–February peak wedding season, when the best designers and karigars (artisans) are fully booked. Lock the Barat outfit first, then sequence the lighter event looks around it. Build this into your overall budget and timeline early."
+    },
+    {
+      "type": "table",
+      "caption": "Bridal ordering timeline",
+      "headers": [
+        "Route",
+        "Design / stitch time",
+        "When to start"
+      ],
+      "rows": [
+        [
+          "Bespoke / custom (Barat)",
+          "8–16 weeks",
+          "4–8 months before (especially Nov–Feb peak)"
+        ],
+        [
+          "Ready-to-wear + alteration",
+          "4–8 weeks",
+          "8–10 weeks before"
+        ],
+        [
+          "Rental",
+          "Days–weeks",
+          "4–6 weeks before"
+        ]
+      ]
+    },
+    {
+      "type": "h2",
+      "text": "Bridal silhouette by body type"
+    },
+    {
+      "type": "p",
+      "text": "The right silhouette flatters your frame. As general guidance: a flared lehenga balances a fuller upper body; an anarkali or A-line gown skims and elongates and suits most frames; a gharara or sharara adds volume and works well on taller or leaner brides; and a fitted mermaid-style maxi flatters an hourglass figure but is less forgiving. Vertical embellishment and longer panels lengthen the line for petite brides, while heavy all-over borders can overwhelm a smaller frame."
+    },
+    {
+      "type": "table",
+      "caption": "Table F — Silhouette by body type",
+      "headers": [
+        "Body type",
+        "Flattering silhouette",
+        "Approach with care"
+      ],
+      "rows": [
+        [
+          "Petite / shorter",
+          "Anarkali, lighter lehenga, vertical detailing",
+          "Heavy floor-trailing farshi gharara, oversized borders"
+        ],
+        [
+          "Tall / lean",
+          "Gharara, sharara, full lehenga, layered styles",
+          "Very minimal narrow cuts that can look plain"
+        ],
+        [
+          "Curvy / fuller",
+          "A-line anarkali, structured lehenga, defined waist",
+          "Clingy mermaid maxi without structure"
+        ],
+        [
+          "Hourglass",
+          "Fitted maxi or mermaid, waist-defining lehenga",
+          "Shapeless tent-like cuts"
+        ]
+      ]
+    },
+    {
+      "type": "h2",
+      "text": "Where to find bridal wear & vendors in your city"
+    },
+    {
+      "type": "p",
+      "text": "Browse bridal-wear designers and boutiques on Wedding Wala by city, then read the four event-by-event spoke guides — Barat, Walima, Mehndi and Nikkah — for detailed outfit direction. Don't forget to book your bridal makeup artist and photographer early, since the best names also fill up for the November–February peak."
+    }
+  ],
+  "faqs": [
+    {
+      "question": "What does a Pakistani bride wear on her Barat?",
+      "answer": "The Barat is the bride's most ceremonial look. Traditionally this is a heavily embellished lehenga-choli or farshi gharara in red, maroon or deep gold — worked with zardozi, dabka and stonework — finished with statement jewellery and a long dupatta. It is the most photographed bridal outfit, so most brides plan it first."
+    },
+    {
+      "question": "What colour should a Pakistani bride wear at each event?",
+      "answer": "By convention, brides wear yellow at the Mayun, festive yellow, green or floral at the Mehndi, white, ivory or soft pastel at the Nikah, red or maroon at the Barat, and elegant pastels at the Walima. These are recognisable conventions rather than strict rules — many brides now mix in deep pinks, rusts, emeralds or pastels for the Barat."
+    },
+    {
+      "question": "What is the difference between a gharara, sharara and lehenga?",
+      "answer": "A lehenga is a flared skirt worn with a fitted blouse (choli) and dupatta. A gharara is a pair of wide trousers flared from the knee and joined at the knee. A sharara flares from the waist with a fuller leg throughout. Gharara and sharara are festive and comfortable (popular for Mehndi and Nikah), while the lehenga is the classic heavy Barat shape."
+    },
+    {
+      "question": "What should a bride wear for her Nikah in Pakistan?",
+      "answer": "Keep the Nikah look understated and modest. A maxi, anarkali or simple gharara in white, ivory or a soft pastel, with restrained embellishment and lighter jewellery, is standard for the religious ceremony. Many families add a dupatta draped over the head."
+    },
+    {
+      "question": "How much does a Pakistani bridal dress cost?",
+      "answer": "Cost varies enormously with fabric, embroidery density, designer and city, so we publish only qualitative bands rather than figures. A bespoke designer Barat lehenga sits in the High band, ready-to-wear with alterations in the Mid band, and rentals (more common for Mehndi or Walima) in the Low band. Always confirm current pricing directly with the designer or boutique."
+    },
+    {
+      "question": "How many months before the wedding should I order my bridal outfit?",
+      "answer": "A bespoke bridal — especially the heavily worked Barat lehenga — usually needs about 8–16 weeks to design, stitch and embroider, and ready-to-wear with alterations roughly 4–8 weeks. For the November–February peak season, book 4–8 months ahead, because the best designers and karigars fill up quickly. Lock the Barat outfit first."
+    },
+    {
+      "question": "Is it better to buy, custom-stitch or rent a bridal dress?",
+      "answer": "Custom-stitch the Barat outfit if you want an exact fit and a keepsake. Choose ready-to-wear with minor alterations for a faster, mid-cost option on lighter events. Rent for single-use Mehndi or Walima looks on a budget — rental typically costs a fraction of buying, though that is indicative, so confirm with the vendor."
+    },
+    {
+      "question": "Which bridal silhouette suits my body type?",
+      "answer": "As general guidance: petite brides suit an anarkali or lighter lehenga with vertical detailing; tall or lean brides carry a gharara, sharara or full lehenga well; curvy or fuller frames flatter an A-line anarkali or a structured, waist-defining lehenga; and an hourglass figure suits a fitted maxi or mermaid cut. Vertical embellishment lengthens the line for shorter brides."
+    }
+  ],
+  "internalLinks": [
+    {
+      "label": "Find bridal-wear designers & boutiques",
+      "href": "/bridal-wear"
+    },
+    {
+      "label": "Barat dress for the bride",
+      "href": "/barat-dress-for-bride"
+    },
+    {
+      "label": "Walima dress for the bride",
+      "href": "/walima-dress-for-bride"
+    },
+    {
+      "label": "Mehndi dress for the bride",
+      "href": "/mehndi-dress-for-bride"
+    },
+    {
+      "label": "Nikkah dress for the bride",
+      "href": "/nikkah-dress-for-bride"
+    },
+    {
+      "label": "Find a bridal makeup artist",
+      "href": "/bridal-makeup-artists"
+    },
+    {
+      "label": "Pakistani wedding events order",
+      "href": "/pakistani-wedding-events-order"
+    }
+  ],
+  "methodologyNote": "Compiled by the Wedding Wala Editorial Team. Event-attire conventions (Mayun/Mehndi festive yellows and florals, understated white or pastel for the Nikah, red or maroon for the Barat, elegant pastels for the Walima), silhouette definitions, fabric and embellishment vocabulary, designer style signatures, body-type and timeline guidance are synthesised across multiple Pakistani and South Asian bridal retail and designer references. Named designers are style references only, not endorsements or price quotes. Cost figures are indicative qualitative bands (High/Mid/Low) from third-party sources, not Wedding Wala quotes — confirm current pricing directly with the designer or boutique. Colour and event conventions are stated as etiquette and taste, not strict rules."
+}

--- a/lib/content/pillars/walima-dress-for-bride.ts
+++ b/lib/content/pillars/walima-dress-for-bride.ts
@@ -1,0 +1,380 @@
+import type { PillarData } from "@/lib/content/pillar-types"
+
+export const data: PillarData = {
+  "slug": "walima-dress-for-bride",
+  "title": "Walima Dress for Bride 2026: Pakistani Reception Colours, Maxis, Lehengas & Cost Bands",
+  "h1": "Walima Dress for the Bride: Colours, Silhouettes, Fabrics & What to Wear for Your Reception",
+  "metaDescription": "A Pakistan-specific walima dress guide for brides: soft pastel colours, maxi vs lehenga vs gown silhouettes, fabrics, designers, rent-vs-buy, indicative cost bands and timeline.",
+  "eyebrow": "Bridal Attire Guide",
+  "updatedLabel": "June 2026",
+  "lead": "For most Pakistani brides, the walima dress is the elegant, contemporary counterpart to the heavy barat look. The convention is soft, refined pastels — ivory, champagne, powder blue, sage, blush or dusty rose — in a flowing maxi or gown, a lighter lehenga, or a structured trail, with noticeably lighter embellishment than the barat. This guide covers the colours, silhouettes, fabrics, designers, costs and timeline to plan it.",
+  "authorName": "Wedding Wala Editorial Team",
+  "breadcrumb": [
+    {
+      "name": "Home",
+      "href": "/"
+    },
+    {
+      "name": "Blog",
+      "href": "/blog"
+    },
+    {
+      "name": "Walima Dress for Bride",
+      "href": "/walima-dress-for-bride"
+    }
+  ],
+  "sections": [
+    {
+      "type": "h2",
+      "text": "What should a bride wear for her walima?"
+    },
+    {
+      "type": "p",
+      "text": "The walima is the groom's-side reception that closes the Pakistani wedding sequence (Mayun, Mehndi, Nikah, Barat, then Walima), and the bride's outfit signals a deliberate shift in mood. Where the barat is heavy, red or maroon and maximally embellished, the walima leans elegant, contemporary and soft. The standard choice is a pastel palette in a flowing silhouette — a maxi or gown, a lighter lehenga, or a softly trailed dress — with refined, restrained embellishment rather than dense, all-over zardozi. To understand where the reception sits in the wedding, see our guide to what walima is in a Pakistani wedding."
+    },
+    {
+      "type": "h2",
+      "text": "How the walima dress differs from the barat dress"
+    },
+    {
+      "type": "p",
+      "text": "The single most useful thing to get right is the contrast between the two looks. The barat is the bride's most ceremonial, traditional moment and calls for deep, rich colour and heavy work; the walima is lighter, softer and more modern. Many brides intentionally choose the walima to feel like the elegant, photogenic 'second look' after the drama of the barat. For the other half of this pairing, see our barat dress for the bride guide."
+    },
+    {
+      "type": "table",
+      "caption": "Table A — Barat vs walima dress at a glance",
+      "headers": [
+        "Aspect",
+        "Barat dress",
+        "Walima dress"
+      ],
+      "rows": [
+        [
+          "Mood",
+          "Most ceremonial, traditional, dramatic",
+          "Elegant, contemporary, refined"
+        ],
+        [
+          "Colour",
+          "Deep red, maroon, rust, deep gold",
+          "Soft pastels: ivory, champagne, powder blue, sage, blush"
+        ],
+        [
+          "Embellishment",
+          "Heavy, dense, all-over",
+          "Lighter, placement-focused, restrained"
+        ],
+        [
+          "Typical silhouette",
+          "Heavy lehenga-choli, gharara, sharara",
+          "Maxi, gown, lighter lehenga, trail"
+        ],
+        [
+          "Weight / comfort",
+          "Heaviest of the wedding",
+          "Lighter, easier to move and dance in"
+        ]
+      ]
+    },
+    {
+      "type": "callout",
+      "text": "These are conventions and etiquette, not strict rules. Plenty of brides wear a soft pink or even a muted red walima look, and regional or family traditions vary. The pastel-and-light norm is a strong, widely-followed guideline — feel free to interpret it to suit your taste.",
+      "label": "Convention, not a rule"
+    },
+    {
+      "type": "h2",
+      "text": "Walima dress colours"
+    },
+    {
+      "type": "p",
+      "text": "The defining feature of the walima look is its soft, refined palette. Pastels and neutrals photograph beautifully under reception lighting and read as elegant rather than overpowering. The most popular walima colours are ivory and off-white, champagne and gold-beige, powder blue, sage and mint green, blush pink, dusty rose, lilac and soft peach. Coordinate your shade with the groom's outfit and the venue decor so the couple's portraits feel intentional."
+    },
+    {
+      "type": "table",
+      "caption": "Table B — Popular walima colours and the mood they set",
+      "headers": [
+        "Colour family",
+        "Examples",
+        "Mood / best for"
+      ],
+      "rows": [
+        [
+          "Ivory & neutral",
+          "Ivory, off-white, champagne, gold-beige",
+          "Timeless, elegant; flatters most skin tones"
+        ],
+        [
+          "Cool pastel",
+          "Powder blue, sage, mint, lilac",
+          "Fresh, modern; daytime and garden receptions"
+        ],
+        [
+          "Warm pastel",
+          "Blush pink, dusty rose, soft peach",
+          "Romantic, soft; flattering in warm light"
+        ],
+        [
+          "Soft jewel (lighter take)",
+          "Muted teal, dusty mauve, soft wine",
+          "For brides wanting colour without barat heaviness"
+        ]
+      ]
+    },
+    {
+      "type": "h2",
+      "text": "Walima silhouettes: maxi vs gown vs lehenga"
+    },
+    {
+      "type": "p",
+      "text": "The walima is where the structured maxi and the flowing gown shine, alongside a lighter lehenga for brides who still want a traditional shape. The walima maxi — a long, fitted-then-flared dress, often with a trail — is one of the most-searched and most-worn reception looks because it is elegant, comfortable and easy to move in. Choose the silhouette that flatters your frame and matches how formal your reception is."
+    },
+    {
+      "type": "table",
+      "caption": "Table C — Walima silhouette comparison",
+      "headers": [
+        "Silhouette",
+        "Shape",
+        "Best for",
+        "Note"
+      ],
+      "rows": [
+        [
+          "Maxi / front-open maxi",
+          "Long fitted-to-flared dress, often trailed",
+          "Most receptions; the popular default",
+          "Elegant, easy to move and dance in"
+        ],
+        [
+          "Gown",
+          "Western-influenced flowing gown",
+          "Contemporary, hotel ballroom receptions",
+          "Most modern; great for trail photos"
+        ],
+        [
+          "Lighter lehenga-choli",
+          "Flared skirt with a fitted choli",
+          "Brides wanting a traditional shape, softened",
+          "Lighter work than the barat lehenga"
+        ],
+        [
+          "Anarkali / peplum",
+          "Frock-style flare / fitted peplum top",
+          "Petite or fuller frames wanting structure",
+          "Anarkali lengthens; peplum defines the waist"
+        ]
+      ]
+    },
+    {
+      "type": "h3",
+      "text": "Which silhouette suits your body type?"
+    },
+    {
+      "type": "p",
+      "text": "Tall, lean brides carry almost anything, including a long gown with a dramatic trail. Petite brides tend to look longer in a high-waisted anarkali or a vertical-panelled maxi. Fuller or hourglass frames are flattered by a fitted-then-flared maxi or a peplum that defines the waist, while a lighter lehenga balances the proportions for those who want a fuller skirt without barat-level weight."
+    },
+    {
+      "type": "h2",
+      "text": "Walima dress fabrics"
+    },
+    {
+      "type": "p",
+      "text": "Because the walima look is lighter and more fluid, the fabrics tend to drape and flow rather than stand stiff. Net, organza and chiffon give movement and a soft trail; raw silk and jamawar add a gentle structure for a more formal frame; velvet appears in winter receptions for warmth and richness. Common embellishment techniques you will hear in the market include dabka, kora, sequins (sitara), pearls, and tilla — used more sparingly than on the barat dress."
+    },
+    {
+      "type": "table",
+      "caption": "Table D — Fabric by walima look and season",
+      "headers": [
+        "Fabric",
+        "Drape / weight",
+        "Best for",
+        "Season"
+      ],
+      "rows": [
+        [
+          "Net / organza",
+          "Light, airy, flowing",
+          "Trailed maxis and gowns",
+          "All / summer-evening"
+        ],
+        [
+          "Chiffon",
+          "Soft, fluid",
+          "Romantic, movement-led looks",
+          "Summer, daytime"
+        ],
+        [
+          "Raw silk",
+          "Light-medium, structured",
+          "Formal maxis, lighter lehengas",
+          "All seasons"
+        ],
+        [
+          "Jamawar",
+          "Medium, woven motifs",
+          "Brides wanting subtle traditional richness",
+          "Winter"
+        ],
+        [
+          "Velvet",
+          "Heavy, plush",
+          "Winter evening receptions",
+          "Winter"
+        ]
+      ]
+    },
+    {
+      "type": "h2",
+      "text": "Designers and where to look for walima dresses"
+    },
+    {
+      "type": "p",
+      "text": "Pakistan's bridal designers cover the full range, from contemporary pastel maxis to lighter formal lehengas. Names you will commonly see for elegant reception looks include Maria B, Elan, Zara Shahjahan, Sania Maskatiya, Suffuse by Sana Yasir, Faraz Manan, HSY, Nomi Ansari, Zainab Chottani, Ali Xeeshan and Kashee's. Designer pieces sit at the higher end of the cost spectrum; well-tailored looks from local boutiques and the bridal markets (such as Lahore's Liberty and Karachi's Tariq Road / Zamzama) offer mid and lower bands. Browse bridal-wear vendors to compare options in your city."
+    },
+    {
+      "type": "h2",
+      "text": "Rent vs buy vs custom-stitch — and indicative cost"
+    },
+    {
+      "type": "p",
+      "text": "Because the walima dress is worn once and is lighter than the barat outfit, many brides find it a good candidate for renting or for a more affordable made-to-order piece. There are three main routes: a bespoke or designer custom dress for an exact fit and a keepsake, a ready-to-wear or boutique piece with minor alterations for speed, or a rental for a single-use, budget-friendly option. The cost guidance below is qualitative (High / Mid / Low bands) — these are not Wedding Wala quotes, and real prices vary widely with fabric, embellishment density, designer and city."
+    },
+    {
+      "type": "table",
+      "caption": "Table E — Rent vs buy vs ready-to-wear (cost bands indicative only)",
+      "headers": [
+        "Option",
+        "Indicative cost band*",
+        "Lead time",
+        "Best for"
+      ],
+      "rows": [
+        [
+          "Custom / designer bespoke",
+          "High (varies widely)",
+          "8-16 weeks; book 4-6 months ahead",
+          "Exact fit, a keepsake, a signature look"
+        ],
+        [
+          "Boutique / ready-to-wear + alteration",
+          "Mid",
+          "3-6 weeks",
+          "Good value, faster turnaround"
+        ],
+        [
+          "Rental",
+          "Typically a fraction of buying",
+          "Days-weeks",
+          "Single-use, budget-conscious brides"
+        ]
+      ]
+    },
+    {
+      "type": "callout",
+      "text": "The cost bands here are indicative only and qualitative (High/Mid/Low) — they are not verified Wedding Wala prices. Rental is usually a fraction of buying. Always confirm current pricing directly with the designer, boutique or vendor, since it depends on fabric, embellishment, designer and city.",
+      "label": "Honesty note on pricing"
+    },
+    {
+      "type": "h2",
+      "text": "When to order your walima dress (timeline)"
+    },
+    {
+      "type": "p",
+      "text": "A bespoke or designer walima dress typically needs around 8-16 weeks once you factor in fittings, while a boutique or ready-to-wear piece with minor alterations runs roughly 3-6 weeks. A practical Pakistani planning point: aim to book 4-6 months ahead for the November-February peak wedding season, when the best designers and tailors fill up fastest. Because the walima often follows the barat by only a day or two, lock both outfits in together rather than leaving the reception look to the last minute. Build this into your overall wedding planning timeline."
+    },
+    {
+      "type": "table",
+      "caption": "Walima dress ordering timeline",
+      "headers": [
+        "Route",
+        "Stitching / prep time",
+        "When to start"
+      ],
+      "rows": [
+        [
+          "Bespoke / designer",
+          "8-16 weeks (with fittings)",
+          "4-6 months before (especially Nov-Feb peak)"
+        ],
+        [
+          "Boutique / ready-to-wear + alteration",
+          "3-6 weeks",
+          "6-8 weeks before"
+        ],
+        [
+          "Rental",
+          "Days-weeks",
+          "4-6 weeks before (to reserve the piece)"
+        ]
+      ]
+    },
+    {
+      "type": "h2",
+      "text": "Completing the walima look: makeup, hair and photography"
+    },
+    {
+      "type": "p",
+      "text": "The walima look is usually softer than the barat all round — a more natural, dewy makeup base, lighter jewellery, and an elegant hairstyle that suits a pastel dress and a flowing trail. Brief your makeup artist on the lighter palette so your look reads cohesive in reception photos, and coordinate the trail and silhouette with your photographer in advance, since the walima often produces some of the most elegant couple portraits of the wedding. Find a bridal makeup artist and a wedding photographer on Wedding Wala."
+    }
+  ],
+  "faqs": [
+    {
+      "question": "What should a Pakistani bride wear for her walima?",
+      "answer": "The walima is the elegant, contemporary reception look. Brides usually wear a soft pastel — ivory, champagne, powder blue, sage, blush or dusty rose — in a flowing maxi or gown, a lighter lehenga, or a softly trailed dress, with lighter embellishment than the barat. The aim is refined and photogenic rather than heavy and ceremonial."
+    },
+    {
+      "question": "What colour should a bride wear for the walima?",
+      "answer": "Soft pastels and neutrals are the convention: ivory, off-white, champagne, powder blue, sage, mint, blush pink, dusty rose, lilac and soft peach. These read as elegant and photograph beautifully under reception lighting. Deep bridal red and maroon are usually saved for the barat, though this is etiquette rather than a strict rule."
+    },
+    {
+      "question": "How is the walima dress different from the barat dress?",
+      "answer": "The barat dress is the bride's most ceremonial look — deep red or maroon, heavily embellished, often a weighty lehenga, gharara or sharara. The walima dress is lighter, softer and more contemporary: pastel colours, restrained embellishment, and flowing silhouettes like a maxi or gown. Many brides treat the walima as the elegant 'second look' after the drama of the barat."
+    },
+    {
+      "question": "What is a walima maxi?",
+      "answer": "A walima maxi is a long, fitted-then-flared dress, often with a trail, that is one of the most popular reception silhouettes. It is elegant, comfortable and easy to move and dance in, which is why many brides choose it over a heavier lehenga for the walima. It works especially well in flowing fabrics like net, organza and chiffon."
+    },
+    {
+      "question": "Should a bride wear a maxi, gown or lehenga for the walima?",
+      "answer": "All three work. A maxi is the popular default — elegant and comfortable. A gown is the most modern, contemporary option and suits hotel ballroom receptions. A lighter lehenga-choli suits brides who still want a traditional shape but softened from the barat. Choose the silhouette that flatters your frame and matches the formality of your reception."
+    },
+    {
+      "question": "How much does a walima dress cost in Pakistan?",
+      "answer": "Costs vary widely with fabric, embellishment, designer and city, so reliable guidance is qualitative. Designer or bespoke pieces sit at the high end, boutique and ready-to-wear in the mid band, and rental typically costs a fraction of buying. These are indicative bands, not Wedding Wala quotes — always confirm current pricing directly with the designer, boutique or vendor."
+    },
+    {
+      "question": "Is it better to rent or buy a walima dress?",
+      "answer": "Because the walima dress is worn once and is lighter than the barat outfit, renting is a popular, budget-friendly choice and usually costs a fraction of buying. Buy or custom-stitch if you want an exact fit, a keepsake, or a signature designer look. A boutique or ready-to-wear piece with minor alterations sits in between on both cost and speed."
+    },
+    {
+      "question": "When should I order my walima dress?",
+      "answer": "A bespoke or designer walima dress usually needs around 8-16 weeks once fittings are included, while a boutique or ready-to-wear piece runs roughly 3-6 weeks. For the November-February peak wedding season, book 4-6 months ahead, since the best designers and tailors fill up quickly. As the walima often follows the barat by a day or two, order both outfits together."
+    }
+  ],
+  "internalLinks": [
+    {
+      "label": "Pakistani bridal dress guide (hub)",
+      "href": "/pakistani-bridal-dress-guide"
+    },
+    {
+      "label": "Barat dress for the bride",
+      "href": "/barat-dress-for-bride"
+    },
+    {
+      "label": "What is walima? Pakistani wedding guide",
+      "href": "/what-is-walima-pakistani-wedding-guide"
+    },
+    {
+      "label": "Find bridal-wear vendors",
+      "href": "/bridal-wear"
+    },
+    {
+      "label": "Find a bridal makeup artist",
+      "href": "/bridal-makeup-artists"
+    },
+    {
+      "label": "Book a wedding photographer",
+      "href": "/wedding-photographers"
+    }
+  ],
+  "methodologyNote": "Compiled by the Wedding Wala Editorial Team. Walima conventions (the elegant, contemporary pastel reception look as a deliberate contrast to the heavy red/maroon barat), colour, silhouette, fabric and styling guidance are synthesised across multiple Pakistani and South Asian bridal retail, designer and editorial references. Designers are named for orientation only; no prices are attributed to them. Cost figures are indicative qualitative bands (High/Mid/Low), not Wedding Wala quotes — confirm current pricing with the designer, boutique or vendor. Colour and styling conventions are stated as etiquette, not strict rules; regional and family traditions vary."
+}

--- a/lib/content/pillars/wedding-photography-cost-in-lahore.ts
+++ b/lib/content/pillars/wedding-photography-cost-in-lahore.ts
@@ -1,0 +1,370 @@
+import type { PillarData } from "@/lib/content/pillar-types"
+
+export const data: PillarData = {
+  "slug": "wedding-photography-cost-in-lahore",
+  "title": "Wedding Photography Cost in Lahore 2026: Packages, Prices & How to Choose",
+  "h1": "Wedding Photography Cost in Lahore: Packages, Prices & How to Choose",
+  "metaDescription": "What does wedding photography cost in Lahore? Indicative PKR package tiers (budget to luxury), what each includes, per-event shooting notes, a how-to-choose checklist, when to book and 8 FAQs.",
+  "eyebrow": "Wedding Photography Guide",
+  "updatedLabel": "June 2026",
+  "lead": "Wedding photography in Lahore typically runs from a few tens of thousands of rupees for single-event budget coverage to several hundred thousand — and PKR 1,000,000+ for luxury multi-day teams. Your final price is driven by the number of events covered, team size, candid vs cinematic work, drone, album quality and how many edited photos you get.",
+  "authorName": "Wedding Wala Editorial Team",
+  "breadcrumb": [
+    {
+      "name": "Home",
+      "href": "/"
+    },
+    {
+      "name": "Blog",
+      "href": "/blog"
+    },
+    {
+      "name": "Wedding Photography Cost in Lahore",
+      "href": "/wedding-photography-cost-in-lahore"
+    }
+  ],
+  "sections": [
+    {
+      "type": "p",
+      "text": "Lahore couples ask the same question first: how much should I budget for the photographer? This guide answers it directly with indicative PKR package tiers, then shows what each tier actually includes, how to read a quote, per-event shooting notes for mehndi, barat, walima and nikah, and a checklist for choosing well. When you are ready to compare real vendors and get live quotes for your dates, compare and contact Lahore wedding photographers on our hub."
+    },
+    {
+      "type": "h2",
+      "text": "How much does a wedding photographer cost in Lahore?"
+    },
+    {
+      "type": "p",
+      "text": "There is no single price — Lahore photography is sold in tiers, and the same studio will quote very differently for a single nikah versus full mehndi + barat + walima coverage. As an indicative guide, budget coverage starts in the tens of thousands of rupees, mid-range multi-event photo-and-video packages sit in the low-to-mid hundreds of thousands, and premium-to-luxury signature teams run from several hundred thousand into PKR 1,000,000 and above. The table below maps what each tier typically buys."
+    },
+    {
+      "type": "callout",
+      "text": "Every PKR figure on this page is an indicative market-research band, not a quote from Wedding Wala or any vendor. These ranges are synthesised from Lahore photography studios and published packages to help you set expectations — the market is volatile and varies by studio, season and exact coverage. Always confirm the actual price with the vendor for your dates.",
+      "label": "Honesty note on pricing"
+    },
+    {
+      "type": "table",
+      "caption": "Table A — Indicative Lahore wedding photography package tiers (PKR — market ranges, not quotes)",
+      "headers": [
+        "Tier",
+        "Indicative PKR",
+        "Days / events",
+        "Edited photos",
+        "Cinematic film",
+        "Album",
+        "Drone",
+        "Team size"
+      ],
+      "rows": [
+        [
+          "Budget",
+          "Tens of thousands (~PKR 25,000–60,000)",
+          "Single event / day",
+          "~150–300 edited",
+          "Short reel or none",
+          "Soft copies only (no print)",
+          "Usually not included",
+          "1 photographer"
+        ],
+        [
+          "Mid-range",
+          "Low six figures (~PKR 80,000–200,000)",
+          "2–3 events",
+          "~400–700 edited",
+          "Highlight film + reel",
+          "Basic printed album",
+          "Add-on",
+          "Photo + video duo / small team"
+        ],
+        [
+          "Premium",
+          "Mid-high six figures (~PKR 250,000–600,000)",
+          "Full multi-event (mehndi, barat, walima)",
+          "~700–1,200 edited",
+          "Cinematic film + reels",
+          "Premium printed album",
+          "Typically included",
+          "Senior lead + second shooters + video crew"
+        ],
+        [
+          "Luxury",
+          "Several hundred thousand to PKR 1,000,000+",
+          "All events, multi-day, signature",
+          "1,000+ edited, fully curated",
+          "Signature cinematic film",
+          "Designer / box album set",
+          "Drone + extras included",
+          "Full crew, multiple leads, dedicated editors"
+        ]
+      ]
+    },
+    {
+      "type": "h3",
+      "text": "What pushes a Lahore quote up or down"
+    },
+    {
+      "type": "ul",
+      "items": [
+        "Number of events and days covered — a single nikah is far cheaper than mehndi + barat + walima across two or three days",
+        "Team size — one shooter versus a senior lead with second shooters and a separate video crew",
+        "Candid and cinematic work — skilled candid coverage and a proper cinematic film cost more than posed stills",
+        "Drone / aerial footage as an add-on versus included in the tier",
+        "Album quality — sheet count, binding and cover, plus extra reels or a second album set",
+        "Area and studio positioning — established studios working DHA, Gulberg and Model Town weddings tend to sit higher than smaller Johar Town or neighbourhood studios"
+      ]
+    },
+    {
+      "type": "h2",
+      "text": "What's included in a wedding photography package"
+    },
+    {
+      "type": "p",
+      "text": "A package is not just 'photos' — it bundles photography, cinematography, deliverables and timelines, and the differences are where quotes diverge. Read every quote against the same checklist so you compare like-for-like rather than headline price alone."
+    },
+    {
+      "type": "h3",
+      "text": "Photography vs cinematography"
+    },
+    {
+      "type": "p",
+      "text": "Photography produces your edited stills and album; cinematography produces motion — the highlight reel and the longer cinematic film. They are often different people on the day and are frequently priced as separate line items. A 'photo + video' package should specify both a stills deliverable and a film deliverable, not just imply one covers the other."
+    },
+    {
+      "type": "h3",
+      "text": "Raw vs edited files"
+    },
+    {
+      "type": "p",
+      "text": "Most studios deliver curated, edited images, not the raw camera files. Raw/unedited files are usually not handed over by default — if you want them, ask upfront and get it written into the contract, as some studios will not release raws at all and others charge extra."
+    },
+    {
+      "type": "table",
+      "caption": "Table B — Typical deliverables and delivery timelines (indicative, varies by vendor and season)",
+      "headers": [
+        "Deliverable",
+        "What it is",
+        "Typical timeline"
+      ],
+      "rows": [
+        [
+          "Sneak peek / soft copies",
+          "A handful of teaser edits soon after the event",
+          "~48 hours to 10 days"
+        ],
+        [
+          "Full edited gallery",
+          "Complete set of colour-corrected, edited stills",
+          "~4–6 weeks (commonly 3–8)"
+        ],
+        [
+          "Highlight reel",
+          "Short, social-ready cinematic edit",
+          "~2–4 weeks"
+        ],
+        [
+          "Cinematic film",
+          "Longer storytelling wedding film",
+          "~4–6 weeks"
+        ],
+        [
+          "Printed album",
+          "Physical album after you finalise selections",
+          "~2–4 weeks after selections finalised"
+        ],
+        [
+          "Raw / unedited files",
+          "Original camera files (only if agreed)",
+          "On request, if offered — often extra"
+        ]
+      ]
+    },
+    {
+      "type": "h3",
+      "text": "Why the album takes longest"
+    },
+    {
+      "type": "p",
+      "text": "The album clock usually starts only once you finalise your photo selections — so client-side delay is the most common reason albums run late, alongside print and binding turnaround at the studio. Decide your picks quickly to keep delivery on track, and get the promised dates into the contract rather than relying on a verbal 'jaldi mil jayega'."
+    },
+    {
+      "type": "h2",
+      "text": "How to choose a wedding photographer in Lahore"
+    },
+    {
+      "type": "p",
+      "text": "Price gets you a shortlist; the checklist below gets you the right vendor. Take it to every studio you meet and note who answers specifically and who stays vague. For the full national framework, see our guide on how to choose a wedding photographer in Pakistan."
+    },
+    {
+      "type": "ul",
+      "items": [
+        "Portfolio consistency — ask to see two or three full weddings, not just a polished highlight reel, so you can judge whether quality holds across an entire event",
+        "Style match — confirm their existing work matches the look you want (traditional/posed, candid storytelling, or cinematic) rather than hoping they can switch",
+        "Written contract — every function, date, deliverable, price and the payment schedule in writing, not a verbal promise",
+        "Backup gear and cameras — ask what happens if a camera or card fails, and whether they shoot to dual cards and carry backup bodies",
+        "Team size and who shoots — confirm the named lead you met will personally shoot your day, and how many second shooters and video crew are included",
+        "Reviews and references — recent client references and reviews, ideally from weddings at venues similar to yours in Lahore",
+        "Low-light capability — most Lahore functions run into the night, so confirm they bring their own lighting and can handle the dim, fast-moving rukhsati"
+      ]
+    },
+    {
+      "type": "callout",
+      "text": "A common Lahore pain point: you meet a senior photographer but a junior associate is sent on the day. Ask directly whether the person you met will personally shoot your wedding, and get the named lead written into the contract.",
+      "label": "Watch for the bait-and-switch"
+    },
+    {
+      "type": "h2",
+      "text": "Photography by event (mehndi, barat, walima, nikah)"
+    },
+    {
+      "type": "p",
+      "text": "Each Pakistani function has its own light, pace and styling — a photographer who knows the flow of a Lahore shaadi will plan for it. Brief them explicitly on every event so nothing is left to assumption."
+    },
+    {
+      "type": "table",
+      "caption": "Table C — Shooting notes by event",
+      "headers": [
+        "Event",
+        "Lighting / setting",
+        "Styling and must-have shots",
+        "Photographer note"
+      ],
+      "rows": [
+        [
+          "Mehndi",
+          "Often outdoor or marquee, runs into the night; warm yellows, fairy lights",
+          "Henna close-ups, ubtan, dhol and dance energy, family colour",
+          "Confirm low-light and off-camera flash skill; candid coverage shines here"
+        ],
+        [
+          "Barat",
+          "Evening hall or lawn; bright stage lighting against darker surroundings",
+          "Groom's entry, stage portraits, bride's reveal, family group shots",
+          "Plan the group-shot list in advance to save time on the stage"
+        ],
+        [
+          "Walima",
+          "Reception hall, formal lighting; the host side's event",
+          "Couple portraits, reception decor, guest greetings, table moments",
+          "Confirm whether couple portraits are a separate dedicated session"
+        ],
+        [
+          "Nikah",
+          "Can be daytime or evening; intimate, often indoor",
+          "Ijab-o-qubool moment, nikah-nama signing, the ring, elders' blessings",
+          "Quiet, fast-moving key moments — see our nikah and rukhsati notes"
+        ]
+      ]
+    },
+    {
+      "type": "h3",
+      "text": "Night events and load-shedding"
+    },
+    {
+      "type": "p",
+      "text": "Mehndi, barat and most receptions run late, and the rukhsati farewell is usually dim, emotional and fast-moving — the single most-missed sequence. Ask how the photographer handles low light and whether they bring their own lighting, since venue lighting can dip during load-shedding. A photographer who carries off-camera flash and backup light is a real advantage at a Lahore wedding."
+    },
+    {
+      "type": "h2",
+      "text": "Questions to ask before booking"
+    },
+    {
+      "type": "ul",
+      "items": [
+        "Can I see two or three full weddings you shot in Lahore, not just highlight reels?",
+        "Will you personally shoot my wedding, or will an associate be sent?",
+        "How many photographers, second shooters and video crew come with this package?",
+        "How do you handle low-light and night events like the mehndi and rukhsati?",
+        "What is your backup plan if a camera fails or you fall ill?",
+        "How many edited photos do I get, and when does the full gallery arrive?",
+        "Is the cinematic film, album and drone included, or priced separately?",
+        "Do I get the raw/unedited files if I want them?",
+        "What advance do you need to lock my date, and what is the payment schedule?",
+        "What happens to my advance if the wedding is postponed or cancelled?",
+        "Will all of this be in a written contract?"
+      ]
+    },
+    {
+      "type": "h2",
+      "text": "When to book your photographer"
+    },
+    {
+      "type": "p",
+      "text": "Book around 3–6 months ahead, and earlier if your date falls in peak season or you have a specific in-demand photographer in mind. Lahore's wedding calendar concentrates heavily in the cooler months, so the best teams fill up fast."
+    },
+    {
+      "type": "callout",
+      "text": "Lahore's peak runs roughly November to February — the 'Decemberistan' season — when outdoor mehndis and barats are most comfortable and demand for photographers spikes. If your date lands here, shortlist and book early; the most sought-after studios are often gone months in advance.",
+      "label": "Peak-season timing"
+    },
+    {
+      "type": "p",
+      "text": "It is common in Pakistan to pay around 50% as an advance to lock the date, with the balance before or around the event; cited norms run roughly 20–50%. Agree the exact percentage and dates upfront, get a receipt, and put the schedule in writing. Set your overall number first with our budget tool so the photographer line fits the whole plan."
+    }
+  ],
+  "faqs": [
+    {
+      "question": "How much does a wedding photographer cost in Lahore?",
+      "answer": "As an indicative guide, budget single-event coverage runs in the tens of thousands of rupees (roughly PKR 25,000–60,000), mid-range multi-event photo-and-video packages around PKR 80,000–200,000, premium signature teams roughly PKR 250,000–600,000, and luxury multi-day coverage from several hundred thousand into PKR 1,000,000 and above. These are market ranges, not quotes — price depends on events covered, team size, candid vs cinematic work, drone, album and the studio. Always confirm the exact figure with the vendor."
+    },
+    {
+      "question": "How far in advance should I book a wedding photographer in Lahore?",
+      "answer": "Book around 3–6 months ahead, and earlier for the peak winter season — roughly November to February ('Decemberistan') — when Lahore's most in-demand photographers fill up fast. If your date is in peak season or you have a specific photographer in mind, shortlist and book sooner rather than later."
+    },
+    {
+      "question": "What's the difference between wedding photography and cinematography?",
+      "answer": "Photography produces your edited stills and printed album; cinematography produces motion — the short highlight reel and the longer cinematic film. They are often shot by different people on the day and are usually priced as separate line items. A 'photo + video' package should name both a stills deliverable and a film deliverable, so check exactly what is included before you compare prices."
+    },
+    {
+      "question": "How many edited photos do you get with a Lahore wedding package?",
+      "answer": "It varies by tier. Indicatively, budget packages deliver roughly 150–300 edited images, mid-range packages around 400–700, premium packages around 700–1,200, and luxury packages 1,000+ fully curated. Ask each studio for the specific edited-photo count and when the full gallery is delivered, and get both written into the contract — counts and timelines vary by vendor and season."
+    },
+    {
+      "question": "Is drone coverage included in wedding photography packages?",
+      "answer": "Often not in budget and mid-range tiers, where drone is usually an add-on; premium and luxury packages more commonly include it. Confirm whether drone/aerial footage is included or extra, and also check your venue allows it — drones in Pakistan fall under Civil Aviation Authority rules and some venues restrict them outright, so ask the vendor to confirm they can legally operate at your specific location."
+    },
+    {
+      "question": "How should I split my budget between photo and video?",
+      "answer": "There is no fixed rule, but many couples weight photography and cinematography fairly evenly within a combined package, then adjust for what they value most — for example more toward a cinematic film if you want a strong reel, or more toward stills and a premium album if prints matter most. Decide your priority first, then ask studios to quote photo-only, video-only and combined so you can see the split clearly."
+    },
+    {
+      "question": "Do photographers cover all the wedding events (mehndi, barat, walima, nikah)?",
+      "answer": "They can, but coverage of every event is usually a higher tier and priced accordingly — a single nikah is far cheaper than full mehndi + barat + walima coverage across multiple days. Decide which functions you want shot, brief the photographer on each one's timing and lighting, and confirm in the contract exactly which events, dates and venues are covered."
+    },
+    {
+      "question": "What are some tips to save money on wedding photography in Lahore?",
+      "answer": "Cover only the events that matter most rather than every function, choose a smaller team or a single skilled shooter for less critical events, skip or downgrade add-ons like drone and second albums, and book off-peak (outside the November–February rush) where studios may have more flexibility. Always compare like-for-like — match the edited-photo count, deliverables and timelines, not just the headline price — and confirm everything in writing."
+    }
+  ],
+  "internalLinks": [
+    {
+      "label": "Compare & contact Lahore wedding photographers",
+      "href": "/wedding-photographers/lahore"
+    },
+    {
+      "label": "Wedding Photographers",
+      "href": "/wedding-photographers"
+    },
+    {
+      "label": "Wedding Venues in Lahore",
+      "href": "/wedding-venues/lahore"
+    },
+    {
+      "label": "Bridal Makeup Artists in Lahore",
+      "href": "/bridal-makeup-artists/lahore"
+    },
+    {
+      "label": "How to Choose a Wedding Photographer in Pakistan",
+      "href": "/how-to-choose-a-wedding-photographer-in-pakistan"
+    },
+    {
+      "label": "Pakistani Bridal Dress Guide",
+      "href": "/pakistani-bridal-dress-guide"
+    },
+    {
+      "label": "Wedding Budget Planning Tool",
+      "href": "/planning-tools/budget"
+    }
+  ],
+  "methodologyNote": "PKR figures on this page are indicative market ranges synthesised from public Lahore photography studio websites, published packages and industry write-ups — they are not a formal market survey and not quotes from Wedding Wala or any vendor. Tier boundaries, edited-photo counts, advance percentages, booking lead times and delivery timelines are typical norms that vary by studio, coverage and season. Per-event and cultural details reflect standard Lahore wedding practice; drone availability and legality depend on Civil Aviation Authority rules and venue policy and are evolving. No named studio prices, fabricated studio names, or search-volume metrics were used — couples should confirm current pricing directly with vendors.",
+  "publishedAt": "2026-06-15",
+  "updatedAt": "2026-06-15"
+}

--- a/lib/seo/pricing-guide.ts
+++ b/lib/seo/pricing-guide.ts
@@ -1,0 +1,540 @@
+/**
+ * PURE DATA — Pakistan 2026 wedding-vendor indicative pricing, booking
+ * questions, and guide-pillar links.
+ *
+ * Powers reusable sections on the live /[vendor-type]/[city] money pages
+ * (weddingwala.pk). The goal is HELPFUL, HONEST orientation for couples
+ * who don't yet know what a category "should" cost — NOT a quote engine.
+ *
+ * IMPORTANT — honesty rules these bands must respect:
+ *   - These are INDICATIVE market ranges synthesised from public 2025/2026
+ *     Pakistani vendor listings and budget guides (Shadiyana, Shehnai,
+ *     Evento Race, Hanif Rajput, Noor Kada, Laam, Hamara Venue, etc.).
+ *   - They are NOT Wedding Wala quotes and NOT promises. Real prices vary
+ *     by city, area (DHA/Clifton vs. suburbs), season (Nov–Feb peak adds
+ *     20–50%), day (Fri/Sat premium), guest count, and the individual
+ *     vendor. The LIVE vendor prices shown on the page are the source of
+ *     truth — every `note` below says so.
+ *   - Units differ by category on purpose: caterers + venues are quoted
+ *     per head, bridal-wear per outfit, stationery per card, and the rest
+ *     per event / package.
+ *
+ * This module has ZERO runtime dependencies and ZERO side effects. The
+ * getters never throw on an unknown slug — they fall back to null / [].
+ *
+ * Slugs here MUST match VENDOR_TYPES in ./constants.ts.
+ */
+
+export interface PricingTier {
+  tier: string;
+  band: string;
+  includes: string;
+}
+
+export interface VendorTypePricing {
+  tiers: PricingTier[];
+  note: string;
+}
+
+/**
+ * Shared honesty disclaimer suffix. Kept as a constant so the wording stays
+ * consistent across all 11 categories — every `note` ends with this.
+ */
+const INDICATIVE_SUFFIX =
+  "These are indicative market ranges for orientation only — not Wedding Wala quotes. Actual prices vary by city, area, season, day, and vendor; the live vendor prices on this page are the source of truth.";
+
+/**
+ * One entry for EACH of these 11 SEO slugs:
+ *   wedding-venues, wedding-photographers, wedding-planners, caterers,
+ *   wedding-decorators, mehndi-artists, bridal-makeup-artists, bridal-wear,
+ *   wedding-stationery, wedding-cars, wedding-djs
+ */
+export const VENDOR_TYPE_PRICING: Record<string, VendorTypePricing> = {
+  "wedding-venues": {
+    tiers: [
+      {
+        tier: "Budget",
+        band: "PKR 800–1,500/head",
+        includes:
+          "Local marriage hall or community marquee, basic in-house menu, fans or limited AC, seating for the function — best for 150–300 guests on a tight budget.",
+      },
+      {
+        tier: "Mid-range",
+        band: "PKR 1,800–3,000/head",
+        includes:
+          "Established banquet hall or lawn with full AC, in-house catering, parking, stage area and standard lighting — typically 300–500 guests.",
+      },
+      {
+        tier: "Premium",
+        band: "PKR 3,500–6,500/head",
+        includes:
+          "Upscale banquet, hotel ballroom or farmhouse in a prime area, refined menu, generous AC and decor allowance, valet and dedicated coordination — 500+ guests.",
+      },
+      {
+        tier: "Luxury",
+        band: "PKR 200,000–800,000+ flat (lawn / farmhouse rental)",
+        includes:
+          "Rental-only premium lawn or farmhouse where catering, decor and lights are arranged separately — peak-season (Nov–Feb) and Fri/Sat dates carry the highest premiums.",
+      },
+    ],
+    note: `Venue costs are usually quoted per head with food, though premium lawns and farmhouses often charge a flat rental and let you bring outside catering. ${INDICATIVE_SUFFIX}`,
+  },
+
+  "wedding-photographers": {
+    tiers: [
+      {
+        tier: "Budget",
+        band: "PKR 30,000–60,000/event",
+        includes:
+          "Single photographer, one function, traditional photo coverage, edited images delivered digitally — minimal or no cinematic film.",
+      },
+      {
+        tier: "Mid-range",
+        band: "PKR 70,000–130,000/package",
+        includes:
+          "2-person team across 1–2 days, photo plus a short cinematic highlight film, basic reel and one printed album.",
+      },
+      {
+        tier: "Premium",
+        band: "PKR 150,000–300,000/package",
+        includes:
+          "Multi-day coverage (mehndi, barat, walima), full cinematic film, social-media reels, drone, couple shoot and premium album.",
+      },
+      {
+        tier: "Luxury",
+        band: "PKR 330,000–600,000+/package",
+        includes:
+          "Signature studio, large crew, full storytelling films, same-day edits, multiple albums and high-end drone/cinematography across every function.",
+      },
+    ],
+    note: `Photography and cinematography are often priced separately or bundled — always confirm which is included. ${INDICATIVE_SUFFIX}`,
+  },
+
+  "wedding-planners": {
+    tiers: [
+      {
+        tier: "Day-of coordination",
+        band: "PKR 50,000–200,000/event",
+        includes:
+          "On-the-day management only — vendor wrangling, timeline, and run-of-show for a single function so the family can relax.",
+      },
+      {
+        tier: "Partial planning",
+        band: "PKR 100,000–500,000/wedding",
+        includes:
+          "Vendor sourcing and negotiation, budget tracking, and coordination for selected functions — you stay involved in the big decisions.",
+      },
+      {
+        tier: "Full-service",
+        band: "PKR 200,000–1,000,000/wedding",
+        includes:
+          "End-to-end design and execution across mehndi, barat and walima — concept, vendors, logistics, guest management and on-site teams.",
+      },
+      {
+        tier: "Luxury / destination",
+        band: "PKR 1,000,000+/wedding",
+        includes:
+          "Multi-day, multi-city or destination weddings with bespoke design, large production crews and white-glove guest hospitality.",
+      },
+    ],
+    note: `Planner fees are usually separate from venue, catering and decor — sometimes a flat fee, sometimes a percentage of total spend. ${INDICATIVE_SUFFIX}`,
+  },
+
+  "caterers": {
+    tiers: [
+      {
+        tier: "Budget",
+        band: "PKR 800–1,200/head",
+        includes:
+          "Simple desi menu — one rice dish, one or two curries, salad, roti and a basic dessert, served buffet-style. Service staff and crockery may be extra.",
+      },
+      {
+        tier: "Mid-range",
+        band: "PKR 1,300–2,500/head",
+        includes:
+          "Fuller menu (4–6 dishes) with a BBQ item, multiple mains, salads, naan/roti and 1–2 desserts — buffet with basic service staff and crockery.",
+      },
+      {
+        tier: "Premium",
+        band: "PKR 2,800–4,500/head",
+        includes:
+          "Extended menu (7–10 dishes) with live BBQ and handi stations, continental options, dessert spread, full service staff and quality crockery.",
+      },
+      {
+        tier: "Luxury",
+        band: "PKR 5,000–10,000+/head",
+        includes:
+          "Lavish multi-cuisine spread, multiple live stations, premium ingredients, dedicated waiters, fine crockery and presentation for high-end weddings.",
+      },
+    ],
+    note: `Catering is quoted per head — but watch what's bundled: live BBQ stations, service staff, crockery and waiter charges are often priced on top. ${INDICATIVE_SUFFIX}`,
+  },
+
+  "wedding-decorators": {
+    tiers: [
+      {
+        tier: "Budget",
+        band: "PKR 45,000–110,000/event",
+        includes:
+          "Basic stage backdrop, simple floral arrangement, standard lighting and entrance setup for one function.",
+      },
+      {
+        tier: "Mid-range",
+        band: "PKR 120,000–300,000/event",
+        includes:
+          "Themed stage with fresh flowers, draping, walkway/entrance decor, table centerpieces and layered lighting.",
+      },
+      {
+        tier: "Premium",
+        band: "PKR 350,000–600,000/event",
+        includes:
+          "Custom themed design — floral walls, statement stage, full ceiling/draping treatment, LED installations and a coordinated lighting plan.",
+      },
+      {
+        tier: "Luxury",
+        band: "PKR 600,000+/event",
+        includes:
+          "Bespoke large-scale production across multiple functions — imported florals, custom structures, immersive lighting and full venue transformation.",
+      },
+    ],
+    note: `Decor is usually priced per function (mehndi vs. barat differ widely) and scales with stage size, fresh-flower volume and lighting. ${INDICATIVE_SUFFIX}`,
+  },
+
+  "mehndi-artists": {
+    tiers: [
+      {
+        tier: "Budget",
+        band: "PKR 3,000–8,000 (bridal package)",
+        includes:
+          "Simpler Arabic or light Pakistani design on both hands, wrist-length, by an emerging artist — at-home service.",
+      },
+      {
+        tier: "Mid-range",
+        band: "PKR 8,000–17,000 (bridal package)",
+        includes:
+          "Detailed Pakistani/Indian bridal design covering both hands up to wrist or below the elbow, plus feet — by an experienced professional.",
+      },
+      {
+        tier: "Premium",
+        band: "PKR 18,000–35,000 (bridal package)",
+        includes:
+          "Intricate full-coverage bridal mehndi — hands and arms up to the elbow plus feet, with personalised motifs and fine detailing.",
+      },
+      {
+        tier: "Celebrity / signature",
+        band: "PKR 35,000–50,000+ (bridal package)",
+        includes:
+          "Sought-after celebrity artist, fully bespoke heavy bridal coverage, often with assistants for the rest of the family (charged per pair of hands).",
+      },
+    ],
+    note: `Bridal mehndi is priced per booking, while guests' designs are usually charged per pair of hands; intricacy, coverage (wrist vs. elbow) and the artist's name drive the price. ${INDICATIVE_SUFFIX}`,
+  },
+
+  "bridal-makeup-artists": {
+    tiers: [
+      {
+        tier: "Budget",
+        band: "PKR 12,000–25,000/look",
+        includes:
+          "Bridal makeup and basic hairstyling for one function by an emerging artist or local salon — single look, no trial.",
+      },
+      {
+        tier: "Mid-range",
+        band: "PKR 30,000–60,000/look",
+        includes:
+          "Established salon or artist, full bridal makeup and hair, dupatta setting, and often a trial session for one main function.",
+      },
+      {
+        tier: "Premium",
+        band: "PKR 70,000–150,000/look",
+        includes:
+          "Well-known artist, premium products, pre-wedding trial, party/family makeup options and on-location service for the main function.",
+      },
+      {
+        tier: "Luxury / celebrity",
+        band: "PKR 150,000+/look",
+        includes:
+          "Top-tier celebrity artist, multiple looks across functions, dedicated trials, signature techniques and full bridal-party makeup.",
+      },
+    ],
+    note: `Bridal makeup is priced per look/function — confirm whether a trial, hairstyling, dupatta setting and family makeup are included or billed separately. ${INDICATIVE_SUFFIX}`,
+  },
+
+  "bridal-wear": {
+    tiers: [
+      {
+        tier: "Budget / ready-to-wear",
+        band: "PKR 40,000–120,000/outfit",
+        includes:
+          "Ready-made or lightly worked bridal lehenga, gharara or maxi from a high-street brand or local boutique — limited customisation.",
+      },
+      {
+        tier: "Mid-range",
+        band: "PKR 130,000–350,000/outfit",
+        includes:
+          "Semi-custom bridal outfit with substantial embroidery and fitting alterations from an established label or designer boutique.",
+      },
+      {
+        tier: "Premium designer",
+        band: "PKR 350,000–800,000/outfit",
+        includes:
+          "Custom designer bridal (e.g. heavily worked lehenga or gharara) with personal fittings, premium fabrics and hand embellishment.",
+      },
+      {
+        tier: "Luxury couture",
+        band: "PKR 800,000–2,500,000+/outfit",
+        includes:
+          "Top couture house, fully bespoke heavy bridal with extensive zardozi/dabka handwork, multiple fittings and signature design.",
+      },
+    ],
+    note: `Bridal wear is priced per outfit — heavier handwork, custom design and big-name labels move the price sharply; renting is a lower-cost alternative for some brides. ${INDICATIVE_SUFFIX}`,
+  },
+
+  "wedding-stationery": {
+    tiers: [
+      {
+        tier: "Budget",
+        band: "PKR 80–250/card",
+        includes:
+          "Standard printed invitation on quality card stock with single insert — straightforward designs, ordered in bulk.",
+      },
+      {
+        tier: "Mid-range",
+        band: "PKR 250–500/card",
+        includes:
+          "Premium finishes — foil, embossing, vellum wrap, multiple inserts or scroll/passport styles with envelopes.",
+      },
+      {
+        tier: "Premium",
+        band: "PKR 500–1,500/card",
+        includes:
+          "Designer or acrylic invites, custom artwork, wax seals and coordinated insert suites for the full function set.",
+      },
+      {
+        tier: "Luxury / boxed",
+        band: "PKR 1,500–3,500+/box",
+        includes:
+          "Bespoke boxed invitations (often velvet) with mithai/favour compartments, custom design and premium packaging.",
+      },
+    ],
+    note: `Stationery is priced per card (or per box for luxury sets) and depends on material, finish, inserts and order quantity. ${INDICATIVE_SUFFIX}`,
+  },
+
+  "wedding-cars": {
+    tiers: [
+      {
+        tier: "Budget",
+        band: "PKR 15,000–35,000/event",
+        includes:
+          "Standard sedan or family car for the rukhsati with basic fresh or artificial floral decoration and a driver for a few hours.",
+      },
+      {
+        tier: "Mid-range",
+        band: "PKR 35,000–80,000/event",
+        includes:
+          "Premium sedan or SUV (e.g. Mercedes E-Class, Audi) with chauffeur, fuller decoration and several hours of coverage.",
+      },
+      {
+        tier: "Premium",
+        band: "PKR 80,000–150,000/event",
+        includes:
+          "Luxury car (Mercedes S-Class, BMW 7 Series, Maybach) with chauffeur for ~8 hours and premium floral or ribbon decoration.",
+      },
+      {
+        tier: "Luxury / exotic",
+        band: "PKR 150,000–300,000+/event",
+        includes:
+          "Top-end or exotic car (e.g. Rolls-Royce, Maybach) with chauffeur, bespoke decoration and full-day availability.",
+      },
+    ],
+    note: `Car rental is priced per event/day and usually excludes the floral decoration (commonly PKR 3,000–5,000), extra hours and out-of-city travel. ${INDICATIVE_SUFFIX}`,
+  },
+
+  "wedding-djs": {
+    tiers: [
+      {
+        tier: "Budget",
+        band: "PKR 20,000–50,000/event",
+        includes:
+          "Basic DJ with a compact sound system and standard lighting for one function — curated playlist, no extras.",
+      },
+      {
+        tier: "Mid-range",
+        band: "PKR 50,000–120,000/event",
+        includes:
+          "Professional DJ with a fuller sound system, dance-floor lighting, wireless mics and a live dhol entry for one or two functions.",
+      },
+      {
+        tier: "Premium",
+        band: "PKR 120,000–250,000/event",
+        includes:
+          "Established DJ act with large PA, LED/effects lighting, MC support and a dhol troupe across multiple functions.",
+      },
+      {
+        tier: "Luxury / live band",
+        band: "PKR 250,000+/event",
+        includes:
+          "Live band or headline performers with full production sound and lighting, multiple slots and bespoke set design.",
+      },
+    ],
+    note: `Entertainment is priced per event — a seasoned dhol pair alone can run up to ~PKR 50,000; sound system, lighting, mics and extra functions add up quickly. ${INDICATIVE_SUFFIX}`,
+  },
+};
+
+/**
+ * 4–6 sharp, PK-relevant "questions to ask before booking" per the same 11
+ * slugs. These are deliberately specific to where Pakistani couples get
+ * surprised (hidden per-head extras, peak-season premiums, who keeps the
+ * RAW footage, in-house vs. outside catering rules, etc.).
+ */
+export const VENDOR_TYPE_QUESTIONS: Record<string, string[]> = {
+  "wedding-venues": [
+    "Is the quoted rate per head with food, or a flat rental where catering is separate?",
+    "Is outside catering allowed, or is in-house catering mandatory?",
+    "Is the price higher for peak season (Nov–Feb) or Friday/Saturday dates?",
+    "Is the whole venue air-conditioned, and is there a generator backup for load-shedding?",
+    "What is the guest capacity, and is parking (and valet) included?",
+    "What is the booking advance, and what is the cancellation or date-change policy?",
+  ],
+  "wedding-photographers": [
+    "Is cinematography (the film) separate from photography in this package, or bundled?",
+    "How many functions and how many days of coverage are included?",
+    "How many photographers and videographers will actually be on site?",
+    "What is the delivery timeline for edited photos, the film, and the album?",
+    "Do we receive the RAW/unedited footage, and are drone shots and reels included?",
+    "What is the advance, and what happens if the lead shooter is unavailable on the day?",
+  ],
+  "wedding-planners": [
+    "Is the fee flat, or a percentage of our total wedding budget?",
+    "Which functions and what scope does this cover — day-of only, partial, or full-service?",
+    "Do you take any commission from vendors you book on our behalf?",
+    "Who from your team will be on-site on the actual function days?",
+    "How do you handle our budget — do we pay vendors directly or through you?",
+    "Have you managed weddings at our shortlisted venues before?",
+  ],
+  "caterers": [
+    "Is the per-head rate inclusive of service staff, waiters and crockery?",
+    "Are live BBQ or handi stations included, or charged on top?",
+    "What is the minimum guest guarantee we have to pay for?",
+    "How many dishes are in this menu, and can we do a tasting beforehand?",
+    "How are extra guests on the night billed, and is there a service or setup charge?",
+    "Do you provide your own setup for outdoor/lawn venues, including generators?",
+  ],
+  "wedding-decorators": [
+    "Is this quote per function, or for all functions (mehndi, barat, walima)?",
+    "Are the flowers fresh or artificial, and how much fresh floral is included?",
+    "Does the price include lighting, draping and the entrance/walkway, or only the stage?",
+    "Is setup and teardown included, and how long before the event do you arrive?",
+    "Does the venue charge a separate fee for outside decorators or for using their structures?",
+    "Can we see photos of a real setup you did, not just inspiration images?",
+  ],
+  "mehndi-artists": [
+    "Is the bridal price for both hands, and up to where — wrist or elbow — plus feet?",
+    "Are family and guest designs charged separately, per pair of hands?",
+    "Do you use natural henna, and how long before the function should it be applied for deep colour?",
+    "Will the named artist apply the bridal mehndi personally, or an assistant?",
+    "Is at-home/at-venue service included, or is there a travel charge?",
+    "Roughly how long will the bridal application take so we can plan the timeline?",
+  ],
+  "bridal-makeup-artists": [
+    "Is a pre-wedding trial included, or charged separately?",
+    "Does the price cover hairstyling and dupatta setting, or just face makeup?",
+    "Which makeup brands and products do you use, and are they suited to the photography lights?",
+    "Is this price per function — and what is the rate for additional functions or looks?",
+    "Do you offer family/bridal-party makeup, and at what per-person rate?",
+    "Will the named artist do the bride personally, and do you travel to our venue?",
+  ],
+  "bridal-wear": [
+    "What is the price for this exact outfit, and what does customisation add?",
+    "How many fittings are included, and how far in advance must we order?",
+    "Is the embroidery handwork (zardozi/dabka) or machine, and on what fabric?",
+    "What is the production timeline, and is there a rush charge for tight dates?",
+    "Are the dupatta, blouse and any accessories included in this price?",
+    "Do you offer a rental option, and what is the deposit and return policy?",
+  ],
+  "wedding-stationery": [
+    "Is the price per card, and how does it change with quantity?",
+    "What finishes are included (foil, embossing, vellum, wax seal) at this price?",
+    "How many inserts come with each invite, and are envelopes included?",
+    "What is the design and printing turnaround, and how many revisions are allowed?",
+    "Is digital proofing included before the full print run?",
+    "What is the cost for boxed or premium versions for close family?",
+  ],
+  "wedding-cars": [
+    "Is floral car decoration included, or charged separately (typically PKR 3,000–5,000)?",
+    "How many hours does the booking cover, and what is the per-hour overtime rate?",
+    "Is a chauffeur included, and is fuel part of the price?",
+    "Is there an extra charge for travel outside the city or to multiple stops?",
+    "Can we see the exact car (model, year, condition) before booking?",
+    "What is the advance, and the policy if the car breaks down on the day?",
+  ],
+  "wedding-djs": [
+    "Is a live dhol included, or is that an add-on to the DJ package?",
+    "How many functions and how many hours does this price cover?",
+    "Is the sound system, dance-floor lighting and a wireless mic for announcements included?",
+    "Will you provide a backup setup and power source in case of load-shedding?",
+    "Can we share a must-play and do-not-play list in advance?",
+    "Is there an MC/host, and what is the overtime rate beyond the booked hours?",
+  ],
+};
+
+/**
+ * Link to the relevant in-depth guide pillar per slug. wedding-djs has no
+ * guide pillar yet, so it is intentionally omitted from this map (the getter
+ * returns null for it).
+ */
+export const VENDOR_TYPE_GUIDE_PILLAR: Record<string, { label: string; href: string }> = {
+  "wedding-venues": {
+    label: "How to Choose a Wedding Venue in Pakistan",
+    href: "/how-to-choose-a-wedding-venue-in-pakistan",
+  },
+  "wedding-photographers": {
+    label: "How to Choose a Wedding Photographer in Pakistan",
+    href: "/how-to-choose-a-wedding-photographer-in-pakistan",
+  },
+  "wedding-planners": {
+    label: "How to Choose a Wedding Planner in Pakistan",
+    href: "/how-to-choose-a-wedding-planner-in-pakistan",
+  },
+  "caterers": {
+    label: "How to Choose a Wedding Caterer in Pakistan",
+    href: "/how-to-choose-a-wedding-caterer-in-pakistan",
+  },
+  "wedding-decorators": {
+    label: "How to Choose a Wedding Decorator in Pakistan",
+    href: "/how-to-choose-a-wedding-decorator-in-pakistan",
+  },
+  "mehndi-artists": {
+    label: "How to Choose a Mehndi Artist in Pakistan",
+    href: "/how-to-choose-a-mehndi-artist-in-pakistan",
+  },
+  "bridal-makeup-artists": {
+    label: "How to Choose a Bridal Makeup Artist in Pakistan",
+    href: "/how-to-choose-a-bridal-makeup-artist-in-pakistan",
+  },
+  "wedding-cars": {
+    label: "How to Choose a Wedding Car in Pakistan",
+    href: "/how-to-choose-a-wedding-car-in-pakistan",
+  },
+  "bridal-wear": {
+    label: "Pakistani Bridal Dress Guide",
+    href: "/pakistani-bridal-dress-guide",
+  },
+  "wedding-stationery": {
+    label: "Pakistani Wedding Invitation Wording",
+    href: "/pakistani-wedding-invitation-wording",
+  },
+};
+
+/** Getters with SAFE fallbacks — never throw on an unknown slug. */
+export function getVendorTypePricing(slug: string): VendorTypePricing | null {
+  return VENDOR_TYPE_PRICING[slug] ?? null;
+}
+
+export function getVendorTypeQuestions(slug: string): string[] {
+  return VENDOR_TYPE_QUESTIONS[slug] ?? [];
+}
+
+export function getVendorTypeGuidePillar(slug: string): { label: string; href: string } | null {
+  return VENDOR_TYPE_GUIDE_PILLAR[slug] ?? null;
+}

--- a/seo-strategy/mega-plan-2yr/00-README.md
+++ b/seo-strategy/mega-plan-2yr/00-README.md
@@ -1,0 +1,90 @@
+# Wedding Wala — 24-Month SEO Mega-Plan (toward 1,000,000 organic visits/mo)
+
+**Domain:** weddingwala.pk · **Market:** Pakistan (locId 2586) · **Horizon:** 24 months · **Drafted:** 2026-06-15
+**Extends:** [`../SEO-MASTER-PLAN.md`](../SEO-MASTER-PLAN.md) (the 12-month, 3-phase plan) → this folder takes it to 24 months and a 1M target.
+
+---
+
+## The honest one-paragraph verdict
+
+**1,000,000 organic visits/month is a genuine stretch ceiling — reachable, not guaranteed.** It is physically possible only because Pakistan's wedding *informational* search universe is enormous (mehndi/dress/decor/hairstyle/cards demand runs into the millions/month). Capturing ~1M means becoming the country's dominant wedding **content** hub (galleries + guides at scale) layered on the **booking** engine, pushing authority from DA 1 toward DA 30+, publishing thousands of quality pages, over a sustained 24 months — and most likely with a small content team (see [10](10-resourcing-conversion-risk.md) §1). Much of any 1M is low-value inspiration traffic, so **the real north star is organic leads/bookings, not the visitor count.** Anyone who *guarantees* 1M is selling hype; this plan instead maximizes the realistic outcome and measures honestly.
+
+---
+
+## How to use this folder
+
+Read in order. Each file is standalone but cross-references the others.
+
+| # | File | What it answers |
+|---|---|---|
+| 00 | **00-README.md** (this) | Governance, canonical conventions, how to use, status |
+| 01 | [01-traffic-model-to-1M.md](01-traffic-model-to-1M.md) | The honest math: demand sizing, 3 scenarios, what 1M requires |
+| 02 | [02-keyword-universe.md](02-keyword-universe.md) | **Canonical** keyword volumes/SD + page-type map + competitor profile |
+| 03 | [03-content-engine.md](03-content-engine.md) | Content types, publishing velocity, E-E-A-T, Urdu, content-ops |
+| 04 | [04-programmatic-architecture.md](04-programmatic-architecture.md) | **Canonical** {vendor}×{city}×{event} matrix, vendor flywheel, thin-page guards |
+| 05 | [05-authority-linkbuilding.md](05-authority-linkbuilding.md) | **Canonical** link/RD targets, digital PR, vendor reciprocity |
+| 06 | [06-technical-geo.md](06-technical-geo.md) | Indexation at scale, CWV/INP, schema, GEO/AI search |
+| 07 | [07-mcp-operating-manual.md](07-mcp-operating-manual.md) | **Canonical** MCP tool-to-job map, Step-Zero, operating cadences |
+| 08 | [08-24-month-roadmap.md](08-24-month-roadmap.md) | Month-by-month execution calendar + decision gates |
+| 09 | [09-measurement-cadence.md](09-measurement-cadence.md) | KPI tree, Looker Studio dashboard spec, review rhythm |
+| 10 | [10-resourcing-conversion-risk.md](10-resourcing-conversion-risk.md) | Budget/headcount, lead/conversion definition, algorithm-risk, competitor roster |
+| 11 | [11-whole-pakistan-coverage.md](11-whole-pakistan-coverage.md) | Real PK geography + exact page-count math (theoretical vs inventory-gated indexable) toward 1M |
+| 12 | [12-page-blueprint.md](12-page-blueprint.md) | The definitive 1000× page blueprint + keyword-placement map (primary/secondary/long-tail → exact on-page slot) |
+| — | [TODO.md](TODO.md) | Master execution checklist |
+| — | [briefs/](briefs/) | Per-page competitor teardowns + "100× better" content briefs |
+
+---
+
+## Canonical conventions (the source-of-truth rules — resolve all cross-file conflicts here)
+
+When two files disagree, **these rules win:**
+
+1. **Plan of record = the Base scenario** ([01](01-traffic-model-to-1M.md) §2.3). The **Aggressive / 1M** scenario is the ceiling we *build for* but never *commit to*. Any file that plans to the Aggressive line as if it were default is wrong and should be read against Base.
+2. **Authority go/no-go gate = referring-domain (RD) count**, not Domain Authority. RD is the (more) first-party signal (GSC Links + Bing). **DA is a secondary, directional, third-party score** — never gate decisions on it. (Resolves the DA-number drift across files.)
+3. **Canonical owners of numbers:**
+   - **Keyword volumes / SD / competitor profile →** [02](02-keyword-universe.md). Other files quote, don't redefine.
+   - **Traffic model, scenarios & page-count ceiling →** [01](01-traffic-model-to-1M.md). The quality-indexed page ceiling is **~4,000 (Base) / ~8,000 (Aggressive)** — *not* the larger "generated/crawlable URL" figures that appear elsewhere (those include `noindex` thin combos and are capacity ceilings, not indexed-page targets).
+   - **Link / RD targets →** [05](05-authority-linkbuilding.md), aligned to Base as plan-of-record.
+   - **MCP usage, Step-Zero, cadences →** [07](07-mcp-operating-manual.md).
+4. **Data labeling discipline (three tiers):**
+   - **Directional** = from Ubersuggest free tier (PK numbers leak US data, only ~19 kw/cluster enriched). Treat as a *floor/sketch*.
+   - **Modeled/illustrative** = forecast outputs with no external source yet (e.g. future impressions/lead ranges). Plausible, not measured.
+   - **Real** = from GSC/GA4/Bing once connected. **Replace directional/modeled numbers with Real the moment Step Zero is done, then re-forecast.**
+5. **North star = organic leads/bookings** ([10](10-resourcing-conversion-risk.md) §2), with **visitors** as a supporting metric. The **informational→commercial internal-link bridge** ([10](10-resourcing-conversion-risk.md) §2.3) is what makes informational volume worth chasing — it is a tracked KPI, not an assumption.
+
+---
+
+## Start here — Step Zero (unblocks everything)
+
+Connect real data before trusting any number in these files:
+1. Create a **Google service-account JSON**, enable Search Console + Analytics Data APIs, add the SA email to GSC (Owner) and GA4 (Viewer).
+2. Wire `gsc` + `ga4` + `bing-webmaster` MCP servers to it (full steps in [07](07-mcp-operating-manual.md) §2).
+3. Define the **GA4 conversion events** (contact reveal / enquiry / WhatsApp click — [10](10-resourcing-conversion-risk.md) §2.1).
+4. Submit `sitemap.xml`, confirm indexation baseline.
+
+Until this is done, the whole plan runs on directional Ubersuggest data. After it's done, the 24/7 measurement loop ([07](07-mcp-operating-manual.md) §5, [09](09-measurement-cadence.md)) goes live.
+
+---
+
+## Maintenance
+
+This is a **living plan**, not a one-shot doc. Re-forecast **quarterly** once GSC is connected (real data replaces directional). Keep [02](02-keyword-universe.md) as the single place to update keyword numbers. Log algorithm incidents and KPI reviews per [10](10-resourcing-conversion-risk.md) §3 / [09](09-measurement-cadence.md) §4.
+
+---
+
+## Known reconciliation backlog (from internal QA — open items, tracked not hidden)
+
+An automated consistency review flagged these. All items are now resolved (reconciliation pass, 2026-06-15):
+
+- **[CLOSED] Cross-reference filenames** → every sibling cross-reference in files 01–09 corrected to the canonical names in the index above; verified zero broken refs remain.
+- **[CLOSED] Page-count tables** → [03](03-content-engine.md) §3 and [09](09-measurement-cadence.md) §1 now split *quality-indexed* (~4k Base / ~8k Aggressive, per rule 3) from *raw generated/crawlable URLs incl. noindex*; the larger figures are explicitly labeled capacity, not targets.
+- **[CLOSED] RD/DA endpoints** → [05](05-authority-linkbuilding.md) now leads with the **Base** plan-of-record (~180 RD/DA~20 @M12; ~350 RD/DA~28 @M24) and labels the ~640 RD / DA 32–37 curve as the **Aggressive** ceiling.
+- **[CLOSED] Gate metric** → authority go/no-go gates in [08](08-24-month-roadmap.md) and [01](01-traffic-model-to-1M.md) switched from DA to **referring-domain count**; DA demoted to a secondary directional signal.
+- **[CLOSED] Budget/resourcing gap →** added in [10](10-resourcing-conversion-risk.md) §1.
+- **[CLOSED] Conversion-surface gap →** added in [10](10-resourcing-conversion-risk.md) §2.
+- **[CLOSED] Algorithm-risk playbook →** added in [10](10-resourcing-conversion-risk.md) §3.
+- **[CLOSED] Competitor roster →** added in [10](10-resourcing-conversion-risk.md) §4.
+
+---
+
+_Drafted 2026-06-15 by the SEO operating system (Claude + 35-server MCP stack). Directional until Step Zero (GSC/GA4/Bing) is connected. Built on the real codebase (Next.js 14 App Router) and live Ubersuggest PK data — no invented metrics._

--- a/seo-strategy/mega-plan-2yr/01-traffic-model-to-1M.md
+++ b/seo-strategy/mega-plan-2yr/01-traffic-model-to-1M.md
@@ -1,0 +1,154 @@
+# 01 — The Honest Traffic Model: weddingwala.pk Toward 1M Organic/mo in 24 Months
+
+*Purpose: a transparent, math-driven model of how — and whether — weddingwala.pk can reach ~1,000,000 organic visitors/month by month 24, with Conservative / Base / Aggressive scenarios, the page-economics behind each, and the honest verdict on what would have to be true.*
+
+> **Read this first.** 1,000,000/mo is a **stretch ceiling we architect toward, not a promise.** Nobody can guarantee rankings or traffic from Domain Authority 1. This document exists to make the assumptions *explicit* so the team can judge progress against reality every quarter. Every Ubersuggest number here is **directional** (PK free-tier leaks US data and undercounts the long tail) and must be replaced with Google Search Console (GSC) truth once connected — see `07-mcp-operating-manual.md` (Step-Zero) and `09-measurement-cadence.md`. The programmatic page math is detailed in `04-programmatic-architecture.md`; this file sizes the *demand* and the *trajectory*.
+
+---
+
+## 1. Sizing the PK wedding organic demand universe
+
+Before modeling capture, we size the pool. The PK wedding search universe splits into two economically different halves.
+
+### 1.1 Informational demand (huge, low-conversion)
+
+This is Pinterest/Google-Images intent — inspiration, designs, galleries. It is where the *volume* lives and where 1M becomes arithmetically conceivable.
+
+| Cluster | Directional volume/mo (PK) | Intent | Conversion to lead |
+|---|---|---|---|
+| "mehndi design" (head) | ~673,000 (SD 47) | Image/inspiration | Near-zero |
+| Mehndi de-duped head universe | ~1,100,000 | Image/inspiration | Near-zero |
+| Broad mehndi long-tail (by body-part/style/occasion/year), enriched | ~1.5M–3M (directional) | Image/inspiration | Near-zero |
+| Bridal-dress *ideas* (designs, photos, color trends) | several 100k | Inspiration → some commercial | Low |
+| Other inspiration (decor ideas, dress ideas, hairstyles, event-order) | several 100k | Inspiration | Low |
+
+**Honest caveat:** mehndi/dress *design* SERPs are dominated by Pinterest, Google Images, and YouTube. Much of this "volume" never produces a blue-link click to a text page (it resolves inside the image carousel). We can capture a *slice* with genuine galleries (`/blog`, `/real-weddings`, pillars in `lib/content/pillars/`), but assume **CTR to our pages is structurally low (1–4%)** on these terms even at good positions.
+
+### 1.2 Commercial demand (smaller, high-value)
+
+This is where bookings and leads come from — the real north star.
+
+| Cluster | Directional volume/mo (PK) | Notes |
+|---|---|---|
+| Bridal-dress *occasion* terms (fastest ROI) | ~60k+ scored, **~52% at SD ≤ 20** | "pakistani wedding dress for bride" 8,100/SD12; "walima dress for bride" 6,600/SD7; "bridal dresses for barat" 4,400/SD8; "nikkah dresses for bride" 3,600/SD8; "bridal gown dress" 14,800/SD20 |
+| Venues (generic + navigational) | tens of thousands | "marriage hall near me" 4,400; "marriage hall" 2,900; venue *names* (blessings marquee 2,400, tulip banquet hall 4,400) — replicable navigational flywheel |
+| {vendor-type} × {city} matrix (11 types × 12 cities) | tens of thousands, long-tail | The bookings engine; mostly SD 8–26 |
+| Vendor-name navigational (per-vendor profile pages) | thousands of low-comp terms | Rank #1 almost uncontested per vendor name |
+| Cost/budget transactional ("wedding cost in pakistan", "{vendor} cost {city}") | thousands | Highest-intent informational; link magnet |
+
+### 1.3 The total pool and the implied capture rate
+
+Summing both halves, the **realistic PK wedding organic universe is several million searches/mo** (informational dominates ~85–90% of raw volume; commercial is the smaller, valuable ~10–15%).
+
+> **The 1M math, stated plainly:** if the addressable pool is ~4–5M searches/mo, then **1M visits/mo ≈ 20–30% capture of the entire PK wedding category.** That is *category leadership* — overtaking shadiyana (DA 22, ~66k/mo) by ~15× and becoming the default PK wedding destination. It is possible only with thousands of indexed pages, DA ~35+, and 24 months of compounding. Treat 20–30% capture as the aggressive ceiling, not the plan of record.
+
+---
+
+## 2. Three scenarios over 24 months
+
+Each scenario is built bottom-up from **pages published × average traffic per page**, cross-checked against an implied capture rate. Page-traffic averages are deliberately blended (a handful of winners carry most traffic; the long tail averages low). **All monthly visitor figures below are deseasonalized annual-averages; real months will swing well above and below them as demand follows the Oct–Feb "Decemberistan" wedding-season peak.**
+
+### 2.1 The page-economics assumptions (made transparent)
+
+| Page type | Aggressive avg visits/mo per *indexed, ranking* page | Why |
+|---|---|---|
+| Informational gallery / mehndi-design post | 150–600 (a few hero posts 10k+) | High volume, low CTR, image-SERP leakage |
+| Money page ({vendor}×{city}, vendor profile) | 15–60 | Low individual volume, high intent, long tail |
+| "Best {vendor} in {city} {year}" listicle | 80–250 | GEO-friendly, mid-volume, good CTR |
+| Cost/budget pillar + city variants | 300–1,500 | High-intent, link-magnet, featured-snippet prone |
+| Brand / direct-nav (over time) | grows with awareness | PR + repeat usage |
+
+> These averages are the load-bearing assumption. If real GSC data shows informational CTR or avg position materially below these, the Aggressive line **must be revised down** — do not defend the 1M number against contrary data.
+
+### 2.2 Conservative scenario (execution slips, DA grind is slow)
+
+Assumes ~1,500 quality-indexed pages by M24, avg position ~12–18 on commercial terms, DA ~18, ~150 referring domains, modest informational capture.
+
+| Milestone | Pages indexed | Avg position (commercial) | DA | Ref. domains | **Visitors/mo** |
+|---|---|---|---|---|---|
+| M3 | ~300 | 30+ | 5 | 15 | **2,000** |
+| M6 | ~600 | 20–25 | 9 | 35 | **12,000** |
+| M9 | ~900 | 16–20 | 12 | 60 | **30,000** |
+| M12 | ~1,100 | 14–18 | 15 | 90 | **60,000** |
+| M18 | ~1,300 | 12–16 | 17 | 130 | **110,000** |
+| M24 | ~1,500 | 12–15 | 18 | 150 | **160,000** |
+
+**Reaching shadiyana's current traffic (~66k) by ~M12 is the Conservative win.** Still a strong outcome.
+
+### 2.3 Base scenario (plan executed competently)
+
+Assumes ~4,000 quality-indexed pages by M24 (full programmatic matrix + listicles + 200+ informational galleries), avg position ~8–12 commercial, real mehndi/dress galleries ranking, DA ~28, ~350 referring domains.
+
+| Milestone | Pages indexed | Avg position (commercial) | DA | Ref. domains | **Visitors/mo** |
+|---|---|---|---|---|---|
+| M3 | ~400 | 28+ | 6 | 25 | **4,000** |
+| M6 | ~900 | 18–22 | 11 | 60 | **25,000** |
+| M9 | ~1,600 | 13–17 | 16 | 120 | **70,000** |
+| M12 | ~2,300 | 10–14 | 20 | 180 | **150,000** |
+| M18 | ~3,200 | 8–12 | 25 | 280 | **320,000** |
+| M24 | ~4,000 | 7–11 | 28 | 350 | **500,000** |
+
+**Base lands at ~500k/mo — roughly half the ceiling, and the most defensible target to plan around.**
+
+### 2.4 Aggressive scenario (the 1M ceiling)
+
+Assumes everything compounds: ~8,000+ quality-indexed pages by M24, **aggressive informational gallery capture** (mehndi/dress/decor design clusters genuinely ranking), avg position ~5–9 commercial, DA ~35+, ~600+ referring domains, sustained content velocity, no major indexation throttling.
+
+| Milestone | Pages indexed | Avg position | DA | Ref. domains | **Visitors/mo** |
+|---|---|---|---|---|---|
+| M3 | ~500 | 25+ | 7 | 35 | **6,000** |
+| M6 | ~1,200 | 16–20 | 13 | 90 | **45,000** |
+| M9 | ~2,500 | 12–15 | 18 | 180 | **130,000** |
+| M12 | ~4,000 | 9–12 | 24 | 300 | **300,000** |
+| M18 | ~6,000 | 6–10 | 30 | 450 | **620,000** |
+| M24 | ~8,000+ | 5–9 | 35+ | 600+ | **1,000,000** |
+
+**Sanity check via two methods:**
+- *Page method:* 8,000 pages × ~125 blended avg visits/mo ≈ 1.0M. The blend only holds if a few hundred informational galleries average 1k–5k+ each.
+- *Capture method:* 1M ÷ ~4.5M pool ≈ **22% category capture** — internally consistent with the page method. Both must be true simultaneously; that is what makes 1M *hard*, not impossible.
+
+---
+
+## 3. Traffic composition at 1M — and how much is actually valuable
+
+Hitting 1M does **not** mean 1M customers. The mix is heavily weighted to low-intent inspiration traffic.
+
+| Source | Share of 1M | Approx visits/mo | Lead value |
+|---|---|---|---|
+| Informational galleries (mehndi designs, dress/decor ideas, hairstyles) | ~55% | ~550,000 | **Very low** — mostly bounce, some assisted discovery |
+| "Best {vendor} in {city}" listicles | ~15% | ~150,000 | **Medium-high** — commercial, converts + AI-cited |
+| Money pages ({vendor}×{city} + vendor profiles) | ~18% | ~180,000 | **High** — direct booking intent |
+| Cost/budget + planning tools | ~7% | ~70,000 | **Medium** — high-intent, top-of-funnel |
+| Brand / direct-nav / "weddingwala" | ~5% | ~50,000 | **High** — repeat + word-of-mouth |
+
+> **The honest read:** at 1M total, only ~**400,000/mo (~40%)** is *commercially valuable* (listicles + money pages + cost + brand). The other ~600k is vanity volume — real, indexable, good for authority and ad-style monetization, but it does **not** book a barat photographer. **The ~400k commercial slice is the number that pays the bills**, and it is far more sensitive to DA and content quality than the mehndi-gallery slice.
+
+---
+
+## 4. The honest verdict
+
+### 4.1 What has to be true for 1M
+
+1. **Referring-domain (RD) count reaches ~600+** (first-party-ish via GSC/Bing, from a near-zero start). This is the single hardest, slowest variable — ~600 quality referring domains via the Decemberistan report, real-wedding vendor credits, PR, and reciprocal vendor links (`05-authority-linkbuilding.md`). **RD count is the go/no-go gating factor**: pages 1–3 don't materialize without the link authority RD measures. DA (~35+ at this point) is only a **secondary, directional** third-party score for sanity-checking the RD trajectory — never gate the decision on it.
+2. **~8,000 genuinely useful, indexed pages** — not thin programmatic doorways. Index bloat from empty {vendor}×{city} combos must be `noindex`-gated (the architecture already auto-filters empties; see `04-programmatic-architecture.md`).
+3. **Sustained content velocity** — hundreds of real informational galleries + city/category depth, refreshed quarterly, for 24 straight months. This is the most common point of failure.
+4. **Informational SERP capture against Pinterest/Google-Images** actually works — the riskiest assumption (below).
+5. **GSC connected at M0** so directional Ubersuggest numbers are replaced by truth and the model is re-forecast each quarter.
+
+### 4.2 The biggest risks (each can cap the model)
+
+| Risk | Why it threatens 1M | Mitigation |
+|---|---|---|
+| **Pinterest/Google-Images SERP capture** | Mehndi/dress *design* queries resolve in image carousels; blue-link CTR may be far below the 1–4% assumed. If informational CTR halves, ~250k–300k of the 1M evaporates. | Win image SEO (alt text, image sitemap — already shipped), structured galleries, video; treat informational as *assist* not *destination*. |
+| **RD plateau (authority ceiling)** | If referring-domain growth stalls (≈350 RD / DA ~22–25 directionally), commercial avg position stalls at ~10–14 and the model caps near **Base (~500k)**. The gate is RD count, not the DA readout. | Make digital PR (Decemberistan data, real-wedding credits) a permanent function, not a one-off. |
+| **Content velocity** | 8,000 quality pages in 24 months ≈ 11+/day sustained. Quality dilution → Google demotes thin programmatic. | Templated-but-unique copy, vendor-data-driven pages, editorial QA gate. |
+| **Indexation at scale** | Google may not index thousands of programmatic pages from a low-DA domain; crawl budget is rationed by authority. | Strong internal linking, sitemap shards (shipped), IndexNow, noindex empties, earn DA first. |
+| **Competitive response** | shadiyana (or a new entrant) closes its non-venue/tier-2/Urdu gaps. | Move fast on the wedge categories now while they're thin. |
+
+### 4.3 Why bookings revenue — not 1M — is the real north star
+
+A 1M-visit month built on mehndi-design galleries is **strategically thin** if it doesn't convert. The platform monetizes **bookings and qualified vendor leads**, which come from the ~400k commercial slice — and that slice is reachable at **Base scenario (~500k total / ~200k commercial)** without ever touching the 1M ceiling.
+
+**Therefore the operating north star is the commercial-traffic-to-lead funnel**, tracked in GA4/GSC: qualified leads, bookings initiated, referring domains, and # of keywords in the top 3 on commercial terms. We *architect toward* 1M because the informational volume builds the authority and brand that lift the commercial pages — but we **measure success in leads.** If forced to choose between +200k mehndi visits and +20k booking-intent visits, take the 20k every time.
+
+> **Bottom line:** plan the budget and team against **Base (~500k/mo by M24)**. Build the infrastructure capable of **Aggressive (1M)** so upside is captured if links, velocity, and image-SERP capture all break our way. Re-forecast every quarter against real GSC data, and never report the vanity number without the lead number beside it.

--- a/seo-strategy/mega-plan-2yr/02-keyword-universe.md
+++ b/seo-strategy/mega-plan-2yr/02-keyword-universe.md
@@ -1,0 +1,154 @@
+# 02 — The Keyword Universe & Page-Type Map
+
+*Purpose: map the entire PK wedding keyword space into prioritized clusters, bind each cluster to a page type and difficulty tier, define the workflow that converts free-tier exports into a fully-scored universe, and end with a repeatable "first 200 keywords" selection method.*
+
+> Read alongside `01-traffic-model-to-1M.md` (the 1M scenario math), `04-programmatic-architecture.md` (how these clusters become URLs at scale), and the root `SEO-MASTER-PLAN.md` (the 12-month tiering this file extends). This file is the *demand-side* atlas; the architecture file is the *supply-side* build.
+
+## 1. How to read this file (the honesty frame)
+
+The 1M organic visits/mo target is an **aggressive-scenario ceiling**, and the keyword universe is *why* it is even arithmetically plausible: the PK wedding search space is several million queries/mo. But the universe is brutally lopsided. Roughly **85–90% of the raw volume is informational** (mehndi designs, dress ideas, hairstyles) — low conversion, Pinterest/Google-Images intent, soft RPM. **Bookings and leads come from a thin commercial subset** (`{vendor}×{city}`, cost/packages, vendor-name navigational) that is maybe **5–10% of the volume but ~80% of the revenue.** Plan to *win the informational mass for reach and DA*, but *measure success on the commercial subset.* Every volume/SD below is **Ubersuggest free-tier PK (locId 2586), directional, a FLOOR** until GSC + paid enrichment replace it (see §7).
+
+## 2. The universe at a glance
+
+| Super-cluster | Intent | Rough PK volume/mo (directional) | Page type | Revenue weight |
+|---|---|---|---|---|
+| Mehndi designs | Informational | 1.1M de-duped head; 1.5–3M long-tail universe | Gallery / blog spoke | Low (DA + reach) |
+| Bridal dress / lehenga / gharara | Commercial-info hybrid | 200k–400k+ | Lookbook + commercial bridge | **High (fast ROI)** |
+| Hairstyles / makeup looks | Informational | 150k–300k | Gallery / tutorial | Low–med |
+| Decor / invitation / jewellery ideas | Informational | 150k–300k | Idea gallery | Low–med |
+| `{vendor}×{city}` | Commercial | 80k–150k | Programmatic listing | **Highest** |
+| Vendor-name navigational | Navigational | 100k–250k (sum of long tail) | Vendor profile | **Highest (flywheel)** |
+| Cost / packages / pricing | Transactional-info | 40k–80k | Cost guide + calculator | **High (link magnet)** |
+| Venue / marquee / hall | Commercial | 60k–120k | Listing + venue profile | **High** |
+
+---
+
+## 3. INFORMATIONAL clusters (the volume mass)
+
+### 3A. Mehndi designs — the single largest cluster
+
+The biggest demand pool in PK weddings. `mehndi design` alone is ~**673,000/mo (SD 47)**; the de-duped mehndi head is ~**1.1M/mo**; enriched across body-part × style × occasion × year the universe is plausibly **1.5–3M/mo**. Head term SD is high, but the **long tail is soft** — best low-difficulty win found so far: `back hand design mehndi` **33,100/SD 14**.
+
+| Representative keyword | Vol | SD | Intent | Target page | Tier |
+|---|---|---|---|---|---|
+| mehndi design | 673,000 | 47 | Info | `/mehndi-designs` pillar hub | C |
+| back hand design mehndi | 33,100 | 14 | Info | `/mehndi-designs/back-hand` | **A** |
+| (front hand / full hand / feet / arabic / minimal / bridal / kids) | enrich | mix | Info | facet spoke per modifier | A–B |
+| mehndi design 2026 / latest | enrich | low–mid | Info | year-freshness spoke | A |
+| simple/easy mehndi design | enrich | low | Info | beginner spoke | A |
+
+**Sub-axes to enumerate (each = an indexable facet page):** body-part (front-hand, back-hand, full-hand, feet/paon, finger, wrist) × style (Arabic, Indian, Pakistani, minimal, floral, mandala, bridal/dulhan) × occasion (bridal, mayun, dholki, eid, engagement) × audience (kids, simple/easy, for beginners) × freshness (2026, latest). **Page type:** answer-first **gallery posts** with 20–40 captioned images, alt text per romanization, `ImageObject` + `HowTo`/`Article` schema, Pinterest-ready vertical assets. **Do NOT make these vendor booking pages** — intent is inspiration. Internal-link every mehndi gallery → `/mehndi-artists/[city]` money page (the conversion bridge). This single cluster can carry a large fraction of any 1M.
+
+### 3B. Hairstyles & makeup looks
+
+`bridal hairstyle`, `walima hairstyle`, `mehndi hairstyle`, `front hair style for wedding`, `bridal makeup look`, `nikkah makeup`, `barat makeup`, `soft glam bridal makeup`. Mid-volume, image-intent. **Page type:** gallery/tutorial spoke; bridge to `/bridal-makeup-artists/[city]`. Difficulty mostly **A–B** on long tail.
+
+### 3C. Decor, invitations/cards, jewellery ideas
+
+`mehndi decoration ideas`, `mayun decor`, `nikkah stage decoration`, `wedding invitation card design`, `mehndi card design`, `bridal jewellery sets`, `matha patti design`. Image + light-commercial. **Page type:** idea galleries → bridge to `/wedding-decorators/[city]`, `/wedding-stationery/[city]`, and a future bridal-jewellery category. Difficulty **A–B** on the modifier long tail.
+
+---
+
+## 4. BRIDAL DRESS cluster — the fastest commercial ROI
+
+This is the **strategic wedge**: high commercial-ish intent yet **LOW difficulty** — roughly **52% of scored bridal-dress volume is SD ≤ 20.** These convert better than mehndi (purchase/shortlist intent) and rank faster than `{vendor}×{city}`. Attack early and hard.
+
+| Keyword | Vol | SD | Intent | Target page | Tier |
+|---|---|---|---|---|---|
+| bridal gown dress | 14,800 | 20 | Commercial-info | `/bridal-wear/gowns` lookbook | **A** |
+| pakistani wedding dress for bride | 8,100 | 12 | Commercial-info | `/bridal-wear/wedding-dresses` | **A** |
+| pakistani bridal dresses | 8,100 | 20 | Commercial-info | `/bridal-wear` hub | **A** |
+| walima dress for bride | 6,600 | 7 | Occasion | `/bridal-wear/walima` | **A** |
+| gharara designs | 6,600 | 20 | Style | `/bridal-wear/gharara` | **A** |
+| nikkah dresses | 6,600 | 21 | Occasion | `/bridal-wear/nikkah` | **A/B** |
+| bridal dresses for barat | 4,400 | 8 | Occasion | `/bridal-wear/barat` | **A** |
+| barat dress for bride | 4,400 | 8 | Occasion | `/bridal-wear/barat` | **A** |
+| mehndi dress for bride | 4,400 | 9 | Occasion | `/bridal-wear/mehndi-dress` | **A** |
+| nikkah dresses for bride | 3,600 | 8 | Occasion | `/bridal-wear/nikkah` | **A** |
+
+**Sub-axes to enumerate:** occasion (barat, walima, mehndi, nikkah, mayun, engagement) × silhouette/style (lehenga, gharara, sharara, maxi, gown, frock, angrakha, peplum) × colour (red, maroon, gold, pastel, white, ivory, green) × designer (HSY, Maria B, Sana Safinaz, Élan, Nomi Ansari — navigational) × price (under 50k, affordable, budget bridal). **Page type:** **lookbook galleries** with `Article`/`ImageObject` schema + a soft commercial CTA bridging to `/bridal-wear/[city]` and bridal-wear vendor profiles. Designer-name pages double as navigational catches. This cluster is the **single best Phase-1 reach+revenue blend** in the universe.
+
+---
+
+## 5. COMMERCIAL clusters (the bookings engine)
+
+### 5A. `{vendor-type} × {city}` matrix
+
+The core money grid — already built programmatically (11 vendor types × 12 cities, auto-filtering empty combos; see `04-programmatic-architecture.md`). Individual cells are low-volume but there are hundreds; aggregate intent is the highest-converting demand in the universe.
+
+| Keyword pattern | Example | Vol | SD | Page | Tier |
+|---|---|---|---|---|---|
+| {vendor} {city} | wedding photographer lahore | 390 | (pos ~43 today) | `/wedding-photographers/lahore` | B |
+| {vendor} near me | wed photographer near me | 170 | 8 | city pages (geo) | **A** |
+| photographer for wedding | (hub) | 1,000 | 14–18 | `/wedding-photographers` | B |
+| makeup artists | (hub/city) | 880 | 24 | `/bridal-makeup-artists/[city]` | B/C |
+
+**Enumeration:** 17 vendor types (11 live + 6 expansion: groom-wear/sherwani, bridal-jewellery, singers/bands, choreographers/dholki, qawwali, wedding-cakes) × 18 cities (Tier-1 metros → Tier-3 long-tail) × modifiers (best, top, near me, affordable, professional). **Page type:** programmatic listing with ≥6 real vendor cards, unique per-city intro, PKR ranges, FAQ + `ItemList` schema. **Thin-page guard:** <3 vendors → `noindex`.
+
+### 5B. Vendor-name navigational — the replicable flywheel
+
+The highest-ROI page type in the plan. Shadiyana bootstrapped its 66k traffic largely by ranking **#1 for individual venue names** via rich profile pages: `empire marquee islamabad` 5,400/#1, `monal marquee` 3,600/#1, `sheesh mahal banquet hall` 2,400/#1, plus `blessings marquee` 2,400, `tulip banquet hall` 4,400 (all volumes directional, Ubersuggest free-tier). Each query is **navigational, near-uncontested, low-difficulty.** Summed across every venue/photographer/makeup-artist/caterer this is **100k–250k/mo of catchable long tail.**
+
+| Keyword | Vol | Intent | Page | Tier |
+|---|---|---|---|---|
+| blessings marquee | 2,400 | Navigational | `/wedding-venues/blessings-marquee` | **A** |
+| sheesh mahal banquet | 2,400 | Navigational | venue profile | **A** |
+| tulip banquet hall | 4,400 | Navigational | venue profile | **A** |
+| {any listed vendor name} | long tail | Navigational | per-vendor profile | **A** |
+
+**Page type:** rich vendor profile (portfolio, reviews, PKR price, map) with `LocalBusiness` + `AggregateRating` schema. **Mass-produce these** — one profile per inventory vendor = one near-guaranteed #1.
+
+### 5C. Cost / packages / pricing — transactional + link magnet
+
+Thin competition, high intent, most-linkable format. `{vendor} cost {city}`, `{vendor} packages price in pakistan`, `catering rates per head {city}`, `how much does a wedding cost in pakistan`, `wedding photography packages lahore`. **Page type:** cost-guide articles + the existing `/planning-tools/budget` calculator (a link magnet competitors lack because theirs is app-locked). FAQ schema, PKR tables, annual freshness. Tier **A–B**; the head `wedding cost in pakistan` is **C** but a top link-bait target.
+
+### 5D. Venues / marquees / halls
+
+`marriage hall near me` 4,400, `marriage hall` 2,900, plus the navigational marquee names in 5B. Venue is shadiyana's fortress — contest it via **profile flywheel + tier-2 cities** rather than head-on for `wedding venues`. **Page type:** `/wedding-venues/[city]` listing + per-venue profiles. Mixed **A (near-me/navigational) → C (head)**.
+
+---
+
+## 6. Difficulty-tier definitions
+
+| Tier | Free-tier SD | Meaning | When to attack |
+|---|---|---|---|
+| **A** | SD ≤ 15 *or* navigational/near-me | Rankable from low DA in weeks | Phase 1 (Mo 1–4) |
+| **B** | SD 16–26 | Needs some on-page depth + a few links | Phase 1–2 (Mo 3–9) |
+| **C** | SD 27+ / head terms | Needs DA ~35+ and topical authority | Phase 3+ (Mo 9–24) |
+
+Mehndi/bridal-dress *heads* are C; their *modifier long tails* are A/B — **always go after the long tail first, let it feed authority up to the head.**
+
+---
+
+## 7. Data-enrichment workflow (turn ~19-enriched exports into a scored universe)
+
+Free-tier `keyword_suggestions` returns large lists but enriches only ~19 rows with volume/SD; everything else is a bare string. Convert the floor into a full scored universe:
+
+1. **STEP ZERO — own data first.** Connect GSC (`gsc`/`search-console-unified`) + GA4 (`ga4`) + Bing Webmaster. Pull Search Analytics queries/pages — these are *real Google* impressions/clicks/position and instantly outrank any Ubersuggest estimate. See `GSC-GA4-SETUP.md`. Seed the universe from every query already earning impressions.
+2. **Harvest the long tail.** For each cluster head run `mcp__ubersuggest__keyword_suggestions` + `google_suggestions` (autocomplete) + `mcp__ubersuggest__content_ideas`; dedupe; this is the raw string pool (thousands of rows).
+3. **Enrich in batches.** Feed the bare strings through `mcp__ubersuggest__keyword_metrics` and `match_keywords` (PK locId 2586) to attach volume + SD beyond the free 19. Budget the 3-domain/day cap by enriching highest-priority clusters first (bridal-dress, vendor×city, cost).
+4. **Validate intent + winnability on the live SERP.** For any keyword you're about to commit a page to, run `serper` (or `mcp__ubersuggest__serp_analysis`) to read the *actual* PK SERP: Is it Pinterest/Images-walled (→ gallery, not money page)? Do DA<25 sites rank (→ winnable)? Is there an AI Overview / People-Also-Ask (→ answer-first + FAQ schema)? This SERP read overrides the SD number.
+5. **Score & cluster.** Compute a priority score per keyword: `Opportunity = (Volume × IntentWeight × CTRtier) / max(SD,1)`, where IntentWeight = 1.0 commercial/navigational, 0.5 transactional-info (dress/cost), 0.2 pure-informational. Tag each row with super-cluster + target page type + A/B/C tier. Store as a typed dataset feeding `lib/content/` and the programmatic engine.
+6. **Refresh quarterly.** GSC reveals new queries you rank for on page 2 (striking-distance) — feed those back as the next enrichment batch. The universe is a living file, not a one-time export.
+
+---
+
+## 8. The "first 200 target keywords" methodology
+
+Do not hand-pick 200; **derive them by formula** so the list is defensible and reproducible.
+
+**Selection rules (apply in order against the §7-scored dataset):**
+
+1. **Pin the proven anchor.** Include the ~1 keyword already indexed (`wedding photographer lahore`, pos ~43) + every GSC query already earning impressions — these are striking-distance freebies.
+2. **Quota by cluster** (balances reach vs revenue):
+   - 60 — **vendor-name navigational** (top-volume venues/photographers in inventory): fastest #1s, builds the flywheel.
+   - 45 — **bridal-dress** SD ≤ 20 (occasion × style × colour): fastest commercial ROI.
+   - 40 — **`{vendor}×{city}`** Tier-A/B for the core-6 vendors × 4 metros + near-me variants: the bookings engine.
+   - 25 — **mehndi long-tail** SD ≤ 20 (body-part/style/2026): reach + DA, e.g. `back hand design mehndi`.
+   - 20 — **cost/packages** (`{vendor} cost {city}`, `wedding cost in pakistan`): link magnets + high intent.
+   - 10 — **other informational bridges** (hairstyles, decor, jewellery) feeding money pages.
+3. **Filter every candidate** through: SERP-validated intent matches the page type (rule §7.4); SD ≤ 20 *or* navigational/near-me; a target page exists or is cheap to generate; not Pinterest-walled unless the page is intentionally a gallery.
+4. **Sequence into sprints.** First-200 ≈ first ~6 months: Sprint 1 = all navigational + bridal-dress SD ≤ 12 (rankable in weeks); Sprint 2 = vendor×city near-me + cost; Sprint 3 = mehndi/bridal-dress SD 13–20.
+5. **Map 1:1 to a page** and an owner; if a keyword has no page, it's not in the 200 — it's a backlog item for `04-programmatic-architecture.md`.
+
+**KPI on the 200:** track in GSC monthly — impressions → clicks → top-3 count, segmented commercial vs informational. The commercial subset's lead/booking volume — not the informational vanity reach — is the real scoreboard, even as the informational mass does the heavy lifting toward any 1M ceiling.

--- a/seo-strategy/mega-plan-2yr/03-content-engine.md
+++ b/seo-strategy/mega-plan-2yr/03-content-engine.md
@@ -1,0 +1,94 @@
+# 03 — The Content Production Engine
+
+> Purpose: define the content system — types, velocity, quality bar, and ops workflow — that produces the page volume and depth Wedding Wala needs to architect toward 1M organic visitors/mo over 24 months, without tipping into thin-content penalties.
+
+This file is the production layer. It assumes the keyword universe and page targets from `02-keyword-universe.md` and the programmatic templates in `04-programmatic-architecture.md`, and it deepens §6 of the existing `../SEO-MASTER-PLAN.md` rather than restating it.
+
+## 1. The honest framing of "content for 1M"
+
+1M/mo is a stretch ceiling, not a forecast. The PK wedding search universe is realistically several million searches/mo, so 1M would mean capturing ~20–30% of it — which requires category leadership, DA ~35+, and thousands of indexed pages. The engine below is built to make that *possible* under the aggressive scenario; the base and conservative scenarios (in `01-traffic-model-to-1M.md`) land far lower and are equally valid.
+
+Critically, most of any 1M is **low-value informational traffic** — "mehndi design" alone is ~673,000/mo (de-duped mehndi head ~1.1M/mo, broad universe plausibly 1.5–3M when enriched). That traffic builds DA, internal-link equity, and AI-citation surface, but it does **not** book weddings. Bookings come from a smaller commercial subset (bridal-dress occasion terms, venue names, {vendor}×{city}). The engine therefore deliberately runs two tracks at different quality/cost tiers and links the cheap-volume track *into* the expensive-conversion track.
+
+## 2. Content types and their role
+
+| Type | Funnel role | Primary KPI | Cost/page | Scale method |
+|---|---|---|---|---|
+| Informational image galleries | Top-of-funnel volume (Pinterest/Images intent) | Sessions, image impressions | Low | Programmatic + curation |
+| "Best {vendor} in {city} 2026" listicles | GEO / AI-citation + mid-funnel conversion | AI citations, CTR to profiles | Medium | Templated + editorial intro |
+| Cost / budget pillars | Link magnets (build the DA we lack) | Referring domains, featured snippets | High | Hand-written, data-backed |
+| Money pages ({vendor}×{city}, detail) | Bookings / leads | Lead form submits, calls | Medium | Programmatic + inventory |
+| Vendor profiles | Navigational flywheel (rank for vendor NAMES) | Branded impressions, profile views | Low | Programmatic from backend |
+
+### 2A. Informational image galleries — the volume floor
+All keyword volumes and SD scores cited in this section are illustrative; `02-keyword-universe.md` is the canonical source for figures — defer to it on any discrepancy.
+
+The mehndi universe is the single biggest reservoir. Build gallery pages sliced by the dimensions the long tail actually searches: body-part ("back hand design mehndi" 33,100/SD14 — our best low-diff win), style (arabic, indian, minimal, full-hand), occasion (bridal, mayun, dholki, eid), and year ("mehndi design 2026"). Each gallery is a real page with curated, captioned, alt-texted images, a 150–250-word intro, a short "how to choose / how it's done" block, and FAQ schema — never a bare image grid (see §6 thin-content guard). These are the cheapest pages to produce and the most defensible against zero-click loss because they win Google Images. Mirror the model for bridal-dress galleries (gharara, barat, walima, nikkah looks), which double as feeders into commercial dress pages.
+
+### 2B. "Best {vendor} in {city} 2026" listicles — the GEO weapon
+This is the highest-priority *new* format (it extends §6B of the master plan). "Best wedding photographers in Lahore 2026" style pages are what AI Overviews, ChatGPT search, and Perplexity quote when users ask "who are the best X in Y" — they are citation-shaped: ranked, named, with rationale. They also outconvert raw {vendor}×{city} grids because they pre-qualify. Each pulls real ranked inventory from the backend, adds a human-written selection methodology, per-vendor blurbs, price-band signals (PKR), and is refreshed annually (2026 → 2027 in the slug/title). Gate behind the existing listicle feature flag and roll out city-by-city as inventory depth justifies it.
+
+### 2C. Cost / budget pillars — the link magnets
+We have DA 1 and 0 referring domains; nothing earns links like proprietary cost data. Build deep, citeable pillars — "How much does a wedding cost in Pakistan 2026", "Marquee vs banquet hall cost", "Bridal makeup price in Lahore/Karachi", "Catering per-head cost & the one-dish law" — each with a real (directional, clearly labelled) price range table, a calculator deep-link to `/planning-tools`, and an annual data refresh. These feed the backlink program in `05-authority-linkbuilding.md` (journalists and bloggers cite cost numbers). Several already exist as pillars (`who-pays-for-what`, `how-to-save-money-on-a-wedding`); the job is to *deepen* with PKR data and visuals, not multiply.
+
+### 2D. Money pages — the booking layer
+{vendor}×{city} (11 vendor types × 12 cities, auto-filtering empty combos), per-vendor detail pages, and the bridal-dress occasion pages (fastest ROI: "walima dress for bride" 6,600/SD7, "bridal dresses for barat" 4,400/SD8, "pakistani wedding dress for bride" 8,100/SD12 — ~52% of scored bridal-dress volume is SD≤20). Content work here is depth: unique city intros, real vendor counts, price bands, neighbourhood notes (DHA/Bahria/Gulberg), and seasonal copy (Decemberistan demand).
+
+### 2E. Vendor profiles — the navigational flywheel
+Shadiyana ranks #1 for individual venue *names* via rich profile pages; that flywheel is replicable and largely free (it rides our backend inventory). Every vendor gets a deep, unique profile (gallery, packages, reviews, AggregateRating + LocalBusiness JSON-LD, map, FAQ). As inventory grows, branded/navigational demand ("blessings marquee" 2,400, "tulip banquet hall" 4,400) becomes thousands of low-competition pages we win by *being the canonical listing*.
+
+## 3. Publishing velocity — 24-month ramp
+
+Velocity is governed by quality gates, not raw output: thin pages get pruned (see §6), so "pages published" only counts pages that clear the bar. Targets are aggressive-scenario; halve them for the base case.
+
+| Phase | Months | Editorial (hand-written) | Programmatic (template) | Cumulative generated/crawlable URLs (incl. noindex) |
+|---|---|---|---|---|
+| 0 — Foundation | 1–3 | 8–12/mo | activate existing {vendor}×{city} + profiles | ~800–1,500 |
+| 1 — Quick wins | 4–9 | 15–20/mo | mehndi/dress galleries + Best-of listicles | ~4,000–8,000 |
+| 2 — Scale | 10–18 | 25–35/mo | full gallery matrix + tier-2 cities + Urdu | ~15,000–30,000 |
+| 3 — Authority | 19–24 | 30–40/mo | long-tail enrichment + refresh cycle | ~40,000–60,000+ |
+
+> Note: the figures above are GENERATED/CRAWLABLE URL capacity (incl. noindex), not an indexed-page target. The QUALITY-INDEXED ceiling is ~4,000 (Base) / ~8,000 (Aggressive) per `01-traffic-model-to-1M.md`.
+
+**What makes this volume safe rather than spammy:**
+- **AI-assisted drafting, human-finished.** AI produces briefs and first drafts; a human edits every page that targets a commercial or YMYL-ish term (cost, legal: nikahnama, court marriage, NADRA). Galleries and profiles are template-generated but every template field is real data, not spun text.
+- **The typed-TS / blog pipeline as the staging layer.** `lib/blog/posts.ts` and the 26 typed pillars in `lib/content/pillars/` let us ship structured, schema-ready content with zero CMS overhead today. The `BlogPost`/`BlogBlock` interfaces enforce structure (typed `h2`/`h3`/`ul`/`p` blocks, author, dates, reading time) so quality is structural, not optional.
+- **The MDX/CMS migration is the throughput unlock.** The pipeline's own header documents the path: MDX files (`content/blog/<cluster>/<slug>.mdx` via next-mdx-remote) → optional headless CMS (Sanity/Strapi) → backend Posts model. Trigger the MDX migration when editorial output exceeds ~20 hand-written posts/mo (≈ Phase 1→2), because hand-editing a TS array stops scaling around there. CMS migration only if a multi-person editorial team materialises; do it additively (keep typed pillars rendering) per the live-system rule.
+
+## 4. Editorial quality bar & E-E-A-T
+
+Wedding Wala is YMYL-adjacent (people spend lakhs on our recommendations; some content is legal — nikahnama clauses, haq mehr, court marriage, NADRA certificates). The bar:
+
+- **Real author bylines, not just "Editorial".** Today `posts.ts` ships a single `wedding-wala-editorial` author. Expand to named humans with photos, real bios, and `/about/<author>` profile pages (the `BlogAuthor.url` field already exists for `Article.author` JSON-LD). Legal/finance pillars need a credited reviewer ("reviewed by") — ideally a real wedding planner or lawyer for E-E-A-T.
+- **First-person experience signals.** "We visited", "vendors told us", real photos from real Pakistani weddings, named venues/cities. This is the *experience* leg of E-E-A-T that AI-spun competitors can't fake.
+- **Replace Pexels with real, licensed photography.** Stock dilutes E-E-A-T and looks non-PK. Source real shaadi imagery via vendor partnerships (vendors supply portfolio shots in exchange for profile placement), real-weddings submissions, and commissioned shoots in key cities. Generic stock acceptable only as a temporary placeholder, flagged for replacement. (The `mcp__plugin_remotion-superpowers_Pexels__*` tools are for staging placeholders only — never the final state.)
+- **Fact-checking & citations.** Every cost figure labelled directional with a date; legal content cites the statute/NADRA source; "best" claims tied to a stated methodology. Annual `updatedAt` refresh on every evergreen page (the field exists; use it — freshness is a ranking and citation signal).
+
+## 5. Urdu / Roman-Urdu content layer
+
+The site is already en-PK default with ur-PK alt + hreflang. A huge slice of PK search is Roman-Urdu and Urdu-script, and competitors are thin here. Plan:
+- **Roman-Urdu first** (highest volume, lowest effort): titles/H1s and key body phrasing that match how people actually type ("shadi hall near me", "mehndi design naya", "barat dress"). Layer onto existing pages as alternate phrasings and FAQs, not duplicate URLs.
+- **Urdu-script** for top informational + high-intent pages via the ur-PK locale, with correct `hreflang` pairing (validate with `seo-hreflang`). Translate, don't machine-dump — a native editor reviews. Start with the mehndi galleries and the cost pillars (broadest reach), then top {vendor}×{city} pages. Keep Urdu additive and flag-gated so an untranslated page never ships a broken alt.
+
+## 6. Thin-content & duplicate guard (programmatic)
+
+Programmatic scale is where penalties happen. Hard rules, enforced in template code and CI:
+- **Minimum unique substance per page:** the substance thresholds (page-specific word counts + required unique data elements) are owned by `04-programmatic-architecture.md` — apply those numbers as canonical rather than a separate figure here. Empty {vendor}×{city} combos already auto-filter — extend that to *noindex (or don't generate)* any gallery/listicle below the canonical substance threshold.
+- **No boilerplate cloning.** City/vendor intros vary by real attributes (neighbourhoods, vendor density, season); never the same paragraph with a token swap. A duplicate-detection check (shingle/cosine over rendered body) in the content-ops pipeline blocks near-duplicates before publish.
+- **Index discipline.** Thin tag/filter permutations stay `noindex`; canonical the year-variants (2025→2026) carefully; keep the sitemap shards reflecting only index-worthy URLs. Monitor index bloat in GSC (Pages report) monthly — see `06-technical-geo.md`.
+- **Prune, don't hoard.** Pages with zero impressions after ~6 months get improved, merged, or removed. "40,000+ indexed pages" is only an asset if they each earn impressions.
+
+## 7. Content-ops workflow (MCP-driven)
+
+A repeatable loop per content batch, using the connected MCP stack. **Step zero is real data:** wire GSC/GA4/Bing so we draft against actual queries, not just directional Ubersuggest.
+
+1. **Trends & demand** → `google-trends` + `mcp__ubersuggest__keyword_suggestions` then enrich the long tail with `keyword_metrics`/`match_keywords` (free tier only enriches ~19/cluster, so enrichment is mandatory); validate live intent with `serper`/`serp_analysis`.
+2. **Gap & SERP shape** → `serper` + `seo-cluster` (SERP-overlap clustering) to confirm page type (gallery vs listicle vs pillar) and what Google rewards; check competitor pages with `firecrawl`.
+3. **Brief** → `seo-content-brief` produces per-section word counts, entities, and the schema target. Brief specifies funnel role, internal-link targets (which money pages this feeds), and Urdu/Roman-Urdu variants.
+4. **Draft** → AI first draft against the brief → human edit (mandatory for commercial/legal). Real images sourced per §4.
+5. **Schema** → `schema-org`/`seo-schema` to generate + validate JSON-LD (Article, FAQPage, ItemList for listicles, ImageObject for galleries, LocalBusiness/AggregateRating for profiles). Must validate clean before publish.
+6. **Publish** → add to typed pipeline (`posts.ts`/pillars) today, MDX post-migration; deploy via the existing additive, flag-gated path (zero-downtime).
+7. **Index** → `indexnow` for instant submission (+ Bing for Copilot citations); confirm with GSC URL Inspection.
+8. **Monitor** → GSC/GA4 for impressions, position, leads; `crux`/`pagespeed` for CWV on new templates; AI-citation tracking (seo-geo / SE Ranking) for the Best-of and pillar layer. Feed losers back into step 4 (refresh) or §6 (prune).
+
+This loop is the recurring heartbeat; the velocity table in §3 is just how many times per month we run it across the two tracks. See `09-measurement-cadence.md` for the dashboards that close it.

--- a/seo-strategy/mega-plan-2yr/04-programmatic-architecture.md
+++ b/seo-strategy/mega-plan-2yr/04-programmatic-architecture.md
@@ -1,0 +1,130 @@
+# 04 — Programmatic SEO Architecture at Scale
+
+*Purpose: define how weddingwala.pk expands its existing Next.js page-generation engine from ~hundreds of indexable URLs to several thousand — additively, flag-gated, zero-downtime — to architect toward the aggressive 1M visits/mo ceiling without triggering Google's thin-programmatic demotion.*
+
+> Read alongside `SEO-MASTER-PLAN.md` (this extends §4–6, not duplicates) and siblings `03-content-engine.md` (content), this file `04-programmatic-architecture.md` §5 (internal-linking), and `06-technical-geo.md` (indexation). **Honesty:** 1M/mo is a stretch ceiling. The page matrix below is the *capacity* to capture it; the *commercial* subset (bookings) is a small fraction of that volume — most programmatic traffic is low-conversion discovery. Build for the leads, count the visits.
+
+---
+
+## 1. The matrix math: where pages come from
+
+The site already runs three programmatic surfaces, all driven by typed config in `lib/seo/constants.ts` (`CITIES`) and `lib/vendor-types.ts` (`VENDOR_TYPES` / `VENDOR_TYPE_PATHS`):
+
+| Surface | Pattern | Driver | Status |
+|---|---|---|---|
+| Vendor-type hub | `/{vendor-type}` | `VENDOR_TYPES` | live (11 SEO routes) |
+| Type × city | `/{vendor-type}/{city}` | `VENDOR_TYPES × CITIES` | live, inventory-gated |
+| Vendor leaf | `/{vendor-type}/{city}/{name}-{id}` | backend `/businesses` feed | live, dynamic |
+| "Best of" listicle | `/best/{vendor-type}-in-{city}` | flag `LISTICLE_PAGES_ENABLED` | built, flag-off |
+
+**Current ceiling.** 11 live SEO vendor types × 12 cities = **132** type×city combos (capacity ceiling — inventory-gated; actual indexed ≪ this), but `buildProgrammaticShard()` only sitemaps combos with ≥1 real vendor — so the *indexable* count tracks inventory, not the theoretical grid. Plus 11 hubs, 12 city hubs, 11 compare pages, 26 content pillars, glossary, blog, real-weddings, and N vendor leaves (one per onboarded business). Today N is small; that is the binding constraint, not template count.
+
+**The three multipliers** that take us from 132 to thousands:
+
+1. **Activate the 14 dormant categories.** `VENDOR_TYPE_PATHS` already declares 23 slugs — the original 9 plus 14 BK-100.55 Pakistani-specific categories (`wedding-officiants`/Nikahkhwan, `wedding-choreographers`, `dhol-players`, `event-hosts`, `live-streaming`, `generator-rental`, `marquee-rental`, `furniture-rental`, `florists`, `wedding-cakes`, `mithai`, `live-cooking-stalls`, `sound-system-rental`, `qawwali`). Each needs a `/{slug}/[city]` route scaffolded (Layer 2). Add the explicitly-named expansion types — **groom-wear/sherwani**, **bridal-jewellery**, **qawwali** (live), **choreographers** (live) — and the SEO grid widens to **~25 types × 12 cities = ~300** combos (capacity ceiling — inventory-gated; actual indexed ≪ this) before any city expansion. Sherwani and bridal-jewellery are net-new and should land in `VENDOR_TYPES` + backend ENUM in lock-step (see the header comment in `lib/vendor-types.ts`).
+
+2. **Tier-2/3 city expansion.** `CITIES` holds 12. Pakistan's wedding economy reaches well past the metros: add Gujrat, Sargodha, Sahiwal, Bahawalnagar, Rahim Yar Khan, Sukkur, Larkana, Mardan, Abbottabad, Mirpur (AJK), Wah Cantt, Jhelum, Sheikhupura, Kasur, Okara. At ~28 cities × ~25 types = **~700** type×city combos (capacity ceiling — inventory-gated; actual indexed ≪ this). Each is inventory-gated, so we publish only as vendors arrive — no empty bloat.
+
+3. **The event layer (the big one).** Pakistani weddings are *multi-function*. Layering events onto the grid is where the long tail explodes: `/{vendor-type}/{city}/{event}` (e.g. `/mehndi-artists/lahore/mayun`, `/wedding-decorators/karachi/dholki`). Events to template, **with variant spellings handled by canonicalization, not duplicate URLs**: mehndi, barat (baraat), walima (valima), mayun (mayoun/maiyun), dholki, nikkah (nikah), rukhsati, sangeet, qawwali-night. Even a conservative subset — 6 high-intent events on the categories where event-intent is real (decor, mehndi, makeup, photography, catering, dhol, choreographer, venue) — adds another large multiplier. **Guard rail:** only build an event page where the event meaningfully changes the offering (a Mehndi makeup look ≠ a Barat look; a Walima venue ≠ a Mayun home setup). Do **not** mint `/wedding-cars/quetta/dholki` — cars don't vary by function. Event eligibility is a per-type flag in config, not a blanket cross-product.
+
+**Net capacity.** ~25 types × ~28 cities × ~6 eligible events (applied selectively) + hubs + leaves + content realistically supports **5,000–15,000 URLs over 24 months** (capacity ceiling — inventory-gated; actual indexed ≪ this) — enough surface to architect toward 1M *if* authority (DA ~35+) and per-page uniqueness keep pace. Page count is necessary, never sufficient.
+
+---
+
+## 2. The vendor-profile navigational flywheel (highest-ROI mass page)
+
+The single highest-ROI programmatic page is the **vendor leaf** at `/{vendor-type}/{city}/{name}-{id}`. This is exactly how shadiyana.pk bootstrapped DA 22: they rank **#1 for individual venue *names*** (empire marquee islamabad — vol 5,400, pos 1; monal marquee — 3,600, pos 1; sheesh mahal banquet hall — 2,400, pos 1) via a rich indexed profile per venue. These are **navigational/branded** queries — low difficulty, high intent, almost uncontested.
+
+**The flywheel:** every vendor we onboard is a new branded keyword we can own from DA 1, because the searcher already wants *that* vendor and we host the canonical page. With ~25 categories (not just venues — photographers, makeup artists, mehndi artists, qawwali troupes, dhol players, sherwani houses), the namespace of brandable queries is far larger than a venue-only competitor's. **This is the mass-page strategy: onboarding velocity = indexable-page velocity = branded-keyword capture.** It also feeds the booking funnel directly (a name search is bottom-of-funnel).
+
+The leaf URL is already canonical and stable (`projectToCanonical()` in `sitemap.ts`): slug + numeric id suffix guarantees uniqueness and survives renames (id is the durable key; the slug is cosmetic). Keep it locked.
+
+---
+
+## 3. Uniqueness per page — avoiding the thin-programmatic penalty
+
+Google demotes programmatic pages that are templated shells with only a swapped city name. Every page type must clear a **uniqueness floor** beyond `{type}` + `{city}` substitution:
+
+- **Type × city pages** already inject `getCityEditorial(city.slug)` (per-city peak-season, venue character) and `getVendorTypeGuide(vt.slug)`, plus four FAQs whose answers vary by city peak season and live PKR price range (`formatPriceRange(vendors)`). **Extend** the editorial corpus so no two cities share boilerplate — local landmarks, average barat guest counts, load-shedding/generator norms (why `generator-rental` matters in summer Multan), regional cuisine for catering. This is content work tracked in `lib/seo/city-editorial.ts`, additive per city.
+- **Vendor leaves** derive uniqueness from real backend data: actual photos, package PKR, reviews (verified-booking only), service area. A leaf with no photos and no description is *itself* thin — gate it (see §4).
+- **Event pages** must carry genuinely event-specific copy (Mayun yellow-theme decor norms, Dholki song/dhol expectations, Walima formal-reception conventions) — never a find-and-replace of the parent. If we can't write 150+ unique words about `{event}` for `{type}` in `{city}`, the page shouldn't exist.
+
+**Rule of thumb:** ship a template only when its *data* makes each instance differ. No data → no page → no thin penalty.
+
+---
+
+## 4. Thin-page noindex guards (the safety valve)
+
+The codebase already implements the correct pattern; we extend, not replace:
+
+- **Type × city:** `components/seo/vendor-type-city-page.tsx` computes `hasListings = vendors.length > 0`; when false it emits `<meta name="robots" content="noindex,follow">` and the combo is excluded from `buildProgrammaticShard()`. The page stays crawlable (links flow) but out of the index — which resolved the GSC *"Crawled – currently not indexed"* warnings from empty combos like `/wedding-djs/quetta`. Pages flip to indexable automatically when the first vendor onboards, **no code change**.
+- **Listicles:** gated twice — `LISTICLE_PAGES_ENABLED` flag **and** `MIN_VENDORS_FOR_LISTICLE = 3` (a "best of" with 2 vendors isn't a ranking). The sitemap mirrors the page's own guard so we never sitemap a 404.
+
+**Extensions to add:**
+
+| Page type | Index threshold | Below threshold |
+|---|---|---|
+| Type × city | ≥1 vendor | `noindex,follow` (existing) |
+| Type × city (strong) | ≥3 vendors | full index + eligible for `/best/` |
+| Event page | ≥3 event-relevant vendors **and** unique copy present | `noindex,follow` |
+| Vendor leaf | has ≥1 photo + description | `noindex,follow` until enriched |
+| City × event hub | ≥2 eligible categories populated | `noindex,follow` |
+
+Centralize the threshold in `lib/seo` (e.g. `MIN_VENDORS_FOR_INDEX`) so all surfaces read one constant. This keeps the indexed set *quality-dense* — the lever that lets DA-1 pages rank at all.
+
+---
+
+## 5. Internal-linking architecture
+
+Programmatic pages need programmatic links — orphan pages don't get crawled, and link equity must flow from hubs toward money pages. The component already renders `otherCities` (6) and `otherTypes` (6) cross-links; formalize the full mesh:
+
+```
+Home
+ └─ Vendor-type hub  /{type}            ──┐ (sibling-type links)
+      └─ Type × city  /{type}/{city}     ─┼─ ↔ City hub /cities/{city} (all types in city)
+           ├─ Vendor leaf /{type}/{city}/{name}-{id}  (money page)
+           └─ Event page /{type}/{city}/{event}  ──→ links up to type×city + sideways to other events
+ Gallery / real-weddings / blog  ──────────→ funnel into type×city + leaf (money pages)
+```
+
+Principles:
+1. **Hub → spoke → leaf, and back.** Every type×city links up to both its type hub and its city hub, sideways to 4–6 sibling types in the same city and the same type in 4–6 nearby cities (region-aware via `CITIES[].region` — Punjab cluster, Sindh cluster), and down to its leaves.
+2. **Gallery → money-page funnels.** Real-weddings recaps and Pinterest-bait galleries (mehndi-design pages absorbing the ~673k–1.1M/mo informational demand) must each link to the relevant commercial pages — `/mehndi-artists/{city}`, `/wedding-decorators/{city}`. This converts low-value informational traffic into the commercial subset; without it the 1M number is purely vanity.
+3. **Contextual, not just footer.** In-body links inside editorial/FAQ copy carry more weight than boilerplate blocks. Generate them from the same typed config so they stay consistent and never 404.
+4. **Breadcrumbs everywhere** (already present, emit `BreadcrumbList` JSON-LD) — they double as crawl paths and SERP enhancements.
+
+---
+
+## 6. URL conventions (respect the locked structure)
+
+The URL grammar is locked (see `docs/seo/03-url-conventions-LOCKED.md`). Non-negotiables for all new programmatic surfaces:
+
+- **No trailing slash; all lowercase; hyphen-delimited.** Slugs via `slugifyName()` only.
+- **Stable, additive paths.** Never rename the original 9 type slugs (`photographers`, `venues`, `bridal-wear`, …) or city slugs — they are canonical SEO URLs with (eventual) equity. New types/cities are pure additions to config.
+- **Event layer extends the path, not query params:** `/{type}/{city}/{event}` — crawlable, not `?event=`.
+- **Spelling variants canonicalize to one URL.** Pick the highest-volume spelling as canonical (e.g. `nikkah` per keyword data, `walima`, `mayun`), 301 the variants, and target the alternates as `<title>`/H-tag/body synonyms — never as separate indexable URLs (that's duplicate-content self-competition).
+- **Locale:** en-PK default, ur-PK alternate via existing hreflang; the `/ur` tree expands additively.
+
+---
+
+## 7. Indexation at scale
+
+Crawl budget and indexation become the real constraint past a few thousand URLs:
+
+- **Sitemap.** Currently one combined `/sitemap.xml` with four logical shards (core, programmatic, vendors, images) — correct under the 50k-URL / 50MB ceilings. The `generateSitemaps()` shard helpers are retained as comments; **re-introduce true sharding the moment the vendor set approaches ~40k URLs** (the threshold is already documented in `sitemap.ts`). Image shard keeps feeding Google Images / Pinterest — critical for the mehndi-design visual demand.
+- **IndexNow.** Wire the existing `indexnow` capability into vendor onboarding and event-page publish so new leaves/combos are submitted to Bing/Yandex instantly — and ping Google via sitemap `lastModified`. Branded leaf pages index fastest when pushed the moment they go live.
+- **Crawl-budget hygiene.** The `noindex,follow` guards (§4) keep Googlebot off thin pages while preserving link flow; `robots.ts` already allowlists AI crawlers. Avoid faceted-filter URL explosions (keep filters in query params that are `noindex` or canonicalized to the clean path). Keep ISR `revalidate: 3600` so `lastModified` stays honest without re-rendering on every request.
+- **Sequencing.** Don't dump 5,000 URLs at once from DA 1 — Google will sample and may distrust the burst. Release in inventory-driven waves (city by city, category by category), matching the master plan's phased assault, so indexation tracks demonstrated quality.
+
+---
+
+## 8. Build sequence (all additive, flag-gated, zero-downtime)
+
+1. Scaffold `[city]` routes for the 14 dormant BK-100.55 slugs (reuse `vendor-type-city-page.tsx`; noindex until populated). No risk — empty combos self-suppress.
+2. Add `groom-wear`/`sherwani` + `bridal-jewellery` to `VENDOR_TYPES` and backend ENUM in lock-step.
+3. Expand `CITIES` with tier-2/3 entries + `city-editorial.ts` copy per new city.
+4. Introduce the event layer behind a flag (`EVENT_PAGES_ENABLED`), per-type event eligibility config, ≥3-vendor + unique-copy guard.
+5. Wire IndexNow into onboarding; add region-aware cross-link mesh.
+6. Flip `LISTICLE_PAGES_ENABLED` once enough combos clear `MIN_VENDORS_FOR_LISTICLE`.
+
+Every step ships dark, gates on real inventory, and degrades to the current site if a flag is off or the backend is unreachable (the sitemap's empty-fallback already proves this discipline). Page capacity is the easy half; the uniqueness floor (§3) and authority build are what convert capacity into the commercial traffic that actually books weddings.

--- a/seo-strategy/mega-plan-2yr/05-authority-linkbuilding.md
+++ b/seo-strategy/mega-plan-2yr/05-authority-linkbuilding.md
@@ -1,0 +1,152 @@
+# 05 — Authority & Link-Building (DA 1 → DA 35+ over 24 months)
+
+> Purpose: the off-page authority engine — the single highest-leverage variable in this whole plan. We start at **0 backlinks / 0 referring domains / DA 1**; shadiyana.pk sits at **DA 22, ~10,312 backlinks / ~850 referring domains**. Closing that gap is *the* moat. Everything in 02-keyword-universe.md, 03-content-engine.md, and 04-programmatic-architecture.md is necessary but **not sufficient** without authority — pages without links do not rank for contested head terms.
+
+---
+
+## 1. The honest framing
+
+Authority is a **lagging, compounding** metric. You cannot buy your way to DA 35 in a quarter without burning the domain. **Plan of record = the BASE case: ~180 RD / DA ~20 at M12 and ~350 RD / DA ~28 at M24** (matching 01-traffic-model-to-1M.md and 08-24-month-roadmap.md) — this is what we build and budget for, and it still unlocks the bulk of commercial rankings. The headline ~640 RD / DA 32–37 growth curve in §2 is the **AGGRESSIVE scenario** — the ceiling that supports the 1M-visitor stretch, never the default. **Gate decisions on RD count, not DA (DA is directional).** **Referring domains (unique linking sites) matter far more than raw backlink count** — 850 referring domains is the number to chase, not 10,000 links. We optimize for *quality, relevance, and Pakistani-context links*, never volume for its own sake.
+
+Why this is winnable: shadiyana's 850 referring domains accumulated over ~8 years, largely passively (venue owners linking back, a handful of press hits). They have **no active PR engine and no vendor-reciprocity program**. We will run both deliberately from month one. Relevance is our edge — a link from a Lahori wedding photographer's site is worth more for *our* topical authority than a generic DA-50 directory.
+
+---
+
+## 2. The 24-month referring-domain growth curve
+
+Targets are **referring domains (RD)** — unique linking root domains — because that is what moves DA. **Gate decisions on RD count, not DA (DA is directional).** Backlink count will run 8–15× RD. DA is Moz's 1–100 log scale; gains get exponentially harder near the top, so the curve front-loads "easy" foundational links and back-loads hard-won editorial/PR links.
+
+**Plan of record (BASE) — build and budget to this:** ~180 RD / DA ~20 at M12, ~350 RD / DA ~28 at M24 (matching 01-traffic-model-to-1M.md and 08-24-month-roadmap.md).
+
+The phase table below traces the **AGGRESSIVE scenario** — the ~640 RD / DA 32–37 ceiling that supports the 1M-visitor stretch, never the default:
+
+| Phase | Months | New RD / mo (target) | Cumulative RD | Est. DA | Dominant link type |
+|---|---|---|---|---|---|
+| **Foundation** | 1–3 | 12–18 | ~45 | 6–10 | Citations, social, GBP, NAP |
+| **Reciprocity ramp** | 4–6 | 18–25 | ~110 | 12–15 | Vendor "Featured on" badges |
+| **Content + outreach** | 7–9 | 20–28 | ~185 | 16–19 | Guest posts, blogger swaps |
+| **First PR flywheel** | 10–12 | 22–30 | ~260 | 20–23 | Wedding Season Report press |
+| **Scale** | 13–18 | 25–35 | ~440 | 26–30 | Mixed: PR + reciprocity + editorial |
+| **Authority consolidation** | 19–24 | 30–40 | ~640 | **32–37** | Editorial, second annual report, partnerships |
+
+**Read:** the ~640 RD / DA 32–37 endpoint above is the **AGGRESSIVE** ceiling (≈ shadiyana's *current* profile, while they're roughly static). The **BASE plan of record is ~350 RD / DA ~28 at M24** (~180 RD / DA ~20 at M12) — even the base is enough to contest most {vendor-type}×{city} and bridal-dress commercial terms. **Gate go/no-go on RD count, not DA (DA is directional).** **Monthly link velocity must look organic** — a smooth ramp, no spikes that trip spam detection. Pair every month's velocity target with a *relevance* check, not just a count.
+
+---
+
+## 3. Foundation layer — citations & NAP (Months 1–3, do first)
+
+These are table-stakes, mostly free, and establish entity consistency for local-pack and AI-citation eligibility. **NAP (Name, Address, Phone) must be byte-identical everywhere** — "Wedding Wala", a single Pakistani business address, one phone, https://www.weddingwala.pk. (Internal note: scrub the legacy "AJOINT" alias from any directory it leaked into; it fractures the entity.)
+
+**Core citations (week 1–2):**
+- **Google Business Profile** — the highest-value single citation; category "Wedding Service / Wedding Planner", service-area covering all 12 cities, weekly Posts, Q&A seeded, photos from /real-weddings.
+- **Bing Places** — feeds Microsoft Copilot citations; mirror GBP exactly (see 06-technical-geo.md for AI-search/GEO).
+- **Apple Business Connect** + **OpenStreetMap/Nominatim** — completes the NAP-verification quartet.
+
+**Pakistani directories & high-authority local citations:**
+- Locanto.com.pk, OLX.com.pk (business listing), PakBiz, Pakistan Business Directory, Findpk, Tuugo.pk, Pakistanidirectory, Brandsynario business listings.
+- **UrduPoint** — major PK portal (DA-strong); pursue a business listing *and* an editorial/directory placement.
+- Wedding-niche aggregators: Shaadi-vendor directories, Hitched-PK-style listings, regional event-portal listings.
+
+**Social profile links (consistent NAP, linked bio):**
+- Instagram (primary — wedding is visual; drives Pinterest/IG referral too), Facebook Page + Facebook Business, YouTube (real-wedding films), Pinterest (critical — mehndi/bridal-dress informational intent funnels here; see the ~673K/mo "mehndi design" universe), TikTok, LinkedIn company page, X.
+
+Foundation realistically yields **40–50 RD** and a DA bump to ~6–10 by month 3. Verify each citation indexes (IndexNow submit + GSC URL inspection).
+
+---
+
+## 4. The vendor-reciprocity engine (the scalable core)
+
+This is our structural advantage and the most defensible link source: **every vendor we list gets a "Featured on Wedding Wala" badge + link to embed on their own site.** Wedding vendors (photographers, makeup artists, venues, decorators) almost all have a website or a Linktree, and they *love* third-party validation to show clients.
+
+**Mechanics (additive, flag-gated — see 04-programmatic-architecture.md):**
+1. On each `/vendor/[slug]` detail page, render a **"Get your Featured badge"** CTA in the vendor dashboard.
+2. Provide a copy-paste HTML snippet: an `<a href>` to their profile URL with an `<img>` badge (host the badge asset; alt text = vendor name). Anchor text rotates naturally — vendor name, "Featured on Wedding Wala", "View our Wedding Wala profile" — **never** exact-match commercial anchors at scale (that's a footprint risk; see §9).
+3. Email/WhatsApp onboarding sequence to all listed vendors: "You're live — here's your badge."
+4. Quarterly "Top-Rated Vendor 2026" awards → a higher-prestige badge vendors are eager to display (these earn the most natural embeds).
+
+**Volume math:** if 1,000 vendors are listed over 24 months and even **15–20% embed the badge**, that's **150–200 RD** from hyper-relevant, in-niche Pakistani wedding sites — a third of the entire RD target, on autopilot. These are the most topically relevant links we can get. **Honesty caveat:** badge links are partially reciprocal; keep the ratio of reciprocal-to-editorial links healthy by pairing this engine with the PR and editorial work below, and never make listing *conditional* on linking (that violates Google guidelines).
+
+---
+
+## 5. Digital PR flywheel (the DA-30+ unlock)
+
+Foundational + reciprocal links get us to ~DA 20. Crossing into the high-20s/30s requires **editorial links from real publications**. Three repeatable plays:
+
+### 5a. Annual "Pakistan Wedding Season Report" (the hero asset)
+Once a year (publish ~October, ahead of **Decemberistan** season), produce an original-data report: *The Pakistan Wedding Season Report* — using **Google Trends** data (search interest for mehndi designs, bridal dresses, venues by city/month), our own aggregate vendor-pricing ranges (PKR), booking-timing patterns, and city-by-city demand. Original data = the one thing journalists reliably link to.
+
+- **Pitch targets:** Dawn (Images/lifestyle desk), Express Tribune, Business Recorder (the wedding *economy* angle — PKR billions spent, vendor employment), The News, Brandsynario, ProPakistani (the search-trends/data angle).
+- **Angles that land:** "Pakistanis now plan weddings X months earlier," "Mehndi searches peak in [month]," "Average barat/walima vendor cost by city," "Decemberistan by the numbers."
+- One strong national hit (Dawn/Tribune) is a DA-50+ editorial link **plus** syndication tails (regional papers re-running it). Target **8–15 RD per report cycle**, with the report page itself becoming a perennial citation magnet.
+
+### 5b. Real-wedding features that credit vendors
+Every story on `/real-weddings` credits each vendor by name with a link to their profile — and we **notify each credited vendor**, who routinely link back to "our feature on Wedding Wala" and share socially. This compounds the reciprocity engine with genuine editorial-style content. Couples also share, earning personal-blog/social links.
+
+### 5c. Styled-shoot & trend pitches to wedding media
+Partner with photographers/decorators on **styled shoots** (a low-cost, high-output content + link play) and pitch the resulting galleries to **Mashion, Diva Magazine, Brides of Pakistan, Something Haute, Galaxy Lollywood (celeb-wedding angle)**. Each feature credits all collaborators (more reciprocal shares) and earns a magazine editorial link. Target **3–6 styled-shoot placements/year**.
+
+---
+
+## 6. Guest content, blogger & photographer partnerships
+
+A steady mid-tier RD stream between the big PR moments:
+
+- **Guest posts** on PK lifestyle/wedding/parenting blogs and Medium-style PK publications — genuinely useful articles (e.g. "How to budget a Lahore walima in 2026"), one contextual link to a relevant pillar (see 03-content-engine.md), not the homepage.
+- **Photographer/MUA cross-promotion:** beyond the badge, co-create content ("5 mehndi looks by [artist]") published on both sites with mutual links — relevant, natural, repeatable.
+- **Micro-influencer & wedding-blogger collabs:** gift features / co-branded checklists embedding our /planning-tools (budget/checklist/timeline) — linkable, useful assets that bloggers cite.
+- **University/community angles:** sponsor or contribute data to bridal expos, wedding fairs (Bridal Couture Week tie-ins) — event sites and recap articles link to sponsors.
+
+Target **5–8 RD/mo** from this lane during Phases 3–6.
+
+---
+
+## 7. HARO / journalist & reactive outreach
+
+Run reactive PR continuously:
+- **HARO / Qwoted / Featured.com / SourceBottle** — answer journalist queries on weddings, events, small-business, South-Asian culture, e-commerce/marketplace topics with a quotable expert reply from a named Wedding Wala spokesperson (E-E-A-T: real person, real title).
+- **Reactive newsjacking:** when a celebrity wedding or a viral wedding-trend story breaks, publish a fast data-backed take and pitch it same-day (Reddit r/pakistan and Google Trends are early signal sources — see §8).
+- Target **2–4 RD/mo** of editorial links here; low hit-rate but high authority per win.
+
+---
+
+## 8. Running link-building on the MCP stack
+
+Operationalize prospecting and qualification with the connected servers:
+
+| Job | Tool(s) | How |
+|---|---|---|
+| **Find link prospects** | serper, exa, g-search | Search "pakistani wedding blog", "write for us wedding pakistan", "{city} wedding photographer blog", competitor backlink anchor footprints |
+| **Steal competitor links** | ubersuggest `backlinks` / `linking_domains` / `backlink_opportunity` on shadiyana.pk | Pull their ~850 RD; filter to repeatable/contactable sources; replicate |
+| **Qualify a prospect** | firecrawl, fetch | Scrape the prospect: DA proxy, contact page, outbound-link health, whether they accept guests; auto-reject spammy/PBN sites |
+| **Story angles & demand** | google-trends, reddit (r/pakistan, r/PAK), tavily | Source data points and trending wedding topics for the annual report + newsjacking |
+| **Get hits indexed fast** | indexnow | Submit new earned-link target pages + the report page the moment they go live |
+| **Track RD growth** | ubersuggest `backlinks_overview`, GSC Links report, bing-webmaster | Monthly RD/DA tracking vs the §2 curve; **GSC is the source of truth once connected — Step Zero** |
+| **Validate badge schema** | schema-org | Ensure badge/profile pages emit clean Organization/LocalBusiness JSON-LD |
+
+Build a simple prospects sheet (status: identified → qualified → contacted → won) and review against the monthly velocity target. **Connect GSC/GA4/Bing first** — real link data replaces directional Ubersuggest numbers (see GSC-GA4-SETUP.md).
+
+---
+
+## 9. Toxic links & disavow note
+
+With aggressive acquisition, monitor for harm:
+- **Audit quarterly** via GSC Links + Ubersuggest backlinks for: sudden RD spikes, irrelevant/foreign-language spam, link-farm/PBN footprints, comment-spam, exact-match commercial anchors at scale.
+- **Anchor-text hygiene:** keep branded ("Wedding Wala") + naked-URL + generic anchors dominant; commercial-keyword anchors well under ~10% of the profile to avoid over-optimization.
+- **Disavow conservatively.** Google mostly ignores spam now; only disavow if you see (a) a clear negative-SEO attack, or (b) a manual action. Maintain a `disavow.txt` but submit only with cause — careless disavowing of borderline-good links does more harm than the spam.
+- **Never buy links, never join link schemes, never make a vendor listing contingent on a link.** One sustained penalty erases two years of compounding. This is live production — every off-page action stays additive and guideline-safe (see live-system-safety standard).
+
+---
+
+## 10. Monthly link-velocity scorecard (track this)
+
+| Metric | Target | Source |
+|---|---|---|
+| New referring domains / mo | per §2 curve (12 → 40) | GSC / Ubersuggest |
+| Reciprocity badge embeds / mo | 8–15 (ramping) | Backlink scan for badge URL |
+| Editorial/PR links / quarter | 8–15 (report) + 2–4/mo HARO | Manual + GSC |
+| Branded-anchor share | dominant (>50%) | Ubersuggest `anchor_texts` |
+| Commercial-anchor share | < 10% | Ubersuggest `anchor_texts` |
+| Toxic-link flags | reviewed quarterly | GSC + audit |
+| DA trajectory | per §2 curve | Ubersuggest (directional) |
+
+**Bottom line:** authority is the rate-limiter on the entire 1M-visitor plan. The reciprocity engine gives us a relevant link compounding loop nobody else in PK wedding is running; the annual Wedding Season Report gives us the editorial DA jumps; foundational citations and HARO fill the gaps. Execute the velocity curve steadily, keep anchors clean, and the BASE plan of record — ~350 RD / DA ~28 by month 24 (~180 RD / DA ~20 at M12) — is what we build to; DA 32–37 / ~640 RD by month 24 is the aggressive ceiling, not the default. **Gate decisions on RD count, not DA (DA is directional).** See 03-content-engine.md for the linkable assets this engine promotes and 06-technical-geo.md for how authority feeds AI-search citations.

--- a/seo-strategy/mega-plan-2yr/06-technical-geo.md
+++ b/seo-strategy/mega-plan-2yr/06-technical-geo.md
@@ -1,0 +1,140 @@
+# 06 — Technical SEO, Core Web Vitals & GEO (AI Search)
+
+> Purpose: keep tens of thousands of weddingwala.pk pages crawlable, fast on PK mobile, correctly marked up, bilingually annotated, and quotable by AI engines — the infrastructure layer beneath the content and link plays in the sibling files (see `04-programmatic-architecture.md`, `03-content-engine.md`, `05-authority-linkbuilding.md`).
+
+This file is the **machine-trust layer** of the 24-month plan. Content gets us into the index; technical correctness decides whether thousands of programmatic pages actually *rank* — and whether AI Overviews, ChatGPT, Perplexity and Copilot *cite* us. Everything here is **additive, flag-gated, zero-downtime**: we already ship `app/sitemap.ts` (4 logical shards + image sitemap, ISR-hourly), `app/robots.ts` (AI-crawler allowlist), `lib/seo/jsonld.ts` (12 typed JSON-LD builders), and `lib/seo/hreflang.ts` (en-PK / ur-PK / x-default). The work below **hardens and monitors** that surface; it does not rebuild it.
+
+Honest framing: a 1M-visits/mo ceiling implies an index of tens of thousands of useful URLs. At that scale the silent killers are **index bloat, crawl waste, and CWV decay on a 3G-ish PK mobile median** — not content gaps. This file exists so growth doesn't strangle itself.
+
+---
+
+## 1. Indexation at scale — get every *useful* page in, keep junk out
+
+At DA 1 with a fresh domain, Google will crawl conservatively. Our job is to make every crawl count and never waste budget on thin or empty URLs.
+
+### 1.1 The empty-combo discipline (already shipped — protect it)
+`buildProgrammaticShard()` already fetches live inventory and **only sitemaps (city × vendor-type) combos with ≥1 real vendor**; zero-vendor combos stay reachable but emit `noindex,follow`. This is the single most important index-bloat guard we have — 12 cities × 11 vendor types = 132 combos, but in tier-2 cities (Quetta, Bahawalpur, Hyderabad) most start empty. **Never** weaken this to "sitemap everything." The same gate guards `/best/[slug]` listicles via `MIN_VENDORS_FOR_LISTICLE`.
+
+### 1.2 Coverage monitoring (which MCP)
+- **`gsc` / `gsc-advanced` / `search-console-unified`** — weekly pull of the Index Coverage / Page Indexing report. Watch three buckets and act:
+  - *Crawled – currently not indexed* → thin/duplicate; deepen content or consolidate (the empty-combo fix above was built specifically to kill this signal).
+  - *Discovered – currently not indexed* → crawl-budget starvation; improve internal links + sitemap freshness.
+  - *Duplicate, Google chose different canonical* → check our self-canonical and hreflang reciprocity (§4).
+- **`gsc` URL Inspection API** — spot-check 10–20 representative URLs per type after each deploy (one vendor leaf, one city hub, one listicle, one pillar, one blog post, one Urdu page) to confirm indexable + correct canonical.
+- **`bing-webmaster`** — parallel coverage report; Bing's index feeds **Microsoft Copilot** citations, so Bing indexation is a GEO dependency, not an afterthought.
+- **`siteaudit` / `seo-audit` / `firecrawl`** — monthly full crawl to catch orphan pages, redirect chains, and `noindex` leaks before Google does.
+
+### 1.3 Sitemap shard health
+We serve a single `/sitemap.xml` (Next 14.2 caveat noted in the file header) but `robots.ts` advertises the logical shards (`/sitemap/0–3.xml`). Monitoring tasks:
+- Confirm each shard stays **< 50k URLs / < 50MB**; the header comment flags re-introducing `generateSitemaps()` when the vendor set approaches the ceiling. At 1M-traffic scale we *will* cross this — pre-build the split now, ship it behind a flag, flip when GSC shows the vendor shard > ~40k.
+- **`lastModified` must be real**, not `new Date()` on every build for static rows — vendor/blog/real-wedding rows already use `updatedAt`. Honest freshness signals are a ranking and a GEO input (§5.4). Audit that static hub rows don't falsely claim daily change.
+- Validate XML well-formedness post-deploy via **`fetch`/`fetcher`** + **`siteaudit`**; alert if image-sitemap (`buildImagesShard`) drops to zero rows (backend outage symptom).
+
+### 1.4 IndexNow — instant discovery
+Use the **`indexnow`** MCP to ping Bing/Yandex (and downstream IndexNow consumers) the moment a page is created or materially updated: new vendor onboarded, new listicle qualifies, new pillar/blog post, price/availability change. Wire a post-revalidate hook so onboarding a Lahore caterer submits its leaf URL within seconds rather than waiting for the hourly ISR + organic crawl. This disproportionately helps a DA-1 site where natural crawl frequency is low.
+
+### 1.5 Crawl-budget hygiene
+`robots.ts` already disallows `/api/`, dashboards, auth, and parameterized noise (`?sort=`, `?page=`, `?utm_*`, `?fbclid=`, `?gclid=`). Additional levers as the grid grows:
+- Keep faceted/sort URLs `noindex` + canonical-to-base; never let filter permutations become crawlable URLs.
+- Internal-link depth ≤ 3 clicks from home to any money page (city hub → vendor-type×city → leaf). Shallow trees spend budget on pages that convert.
+- Monitor **crawl stats in `gsc`** (requests/day, avg response time); a rising response time throttles Google's crawl rate — ties directly to §2.
+
+---
+
+## 2. Core Web Vitals & INP — built for the PK mobile median
+
+PK organic is overwhelmingly Android-on-mobile-data. Optimize for a mid-range phone on a congested network, not a desktop on fibre. **INP (Interaction to Next Paint)** is the 2026 pass/fail most at risk on JS-heavy, image-dense vendor galleries.
+
+### 2.1 Field-data monitoring (which MCP)
+- **`crux` / `pagespeed-crux`** — the source of truth (real Chrome users). Track the **75th-percentile LCP / INP / CLS** monthly per page *type* (origin-level first, then top URLs once they have field data). Targets: LCP ≤ 2.5s, INP ≤ 200ms, CLS ≤ 0.1 — at p75 on **mobile**.
+- **`pagespeed`** (PSI) + **`lighthouse`** — lab diagnostics for pages without field data yet (most of our new programmatic URLs). Run after each template change; lab regressions predict field regressions.
+- **`gsc`** Core Web Vitals report — groups URLs by status; our north-star "good URLs" count.
+- **`chrome-devtools`** — INP attribution / long-task tracing on the worst offenders (vendor detail galleries, search/filter).
+
+### 2.2 Concrete Next.js 14 levers (additive)
+| Lever | Implementation | Vital it moves |
+|---|---|---|
+| Image optimization | `next/image` everywhere; serve AVIF/WebP; explicit `width`/`height` or `fill` + aspect-ratio box; `sizes` tuned for mobile | LCP, CLS |
+| Above-the-fold priority | `priority` on the LCP image only (hero / first gallery shot); lazy-load the rest | LCP |
+| ISR | Programmatic + vendor pages already ISR (`revalidate: 3600`) → served from cache, fast TTFB without per-request backend hits | LCP, TTFB |
+| Lazy-load below-fold | `next/dynamic` (`ssr:false` where safe) for maps, carousels, review widgets, related-vendor rails | INP, TBT |
+| Font discipline | `next/font` (self-host, `display: swap`, subset Latin + Arabic for Urdu) | LCP, CLS |
+| JS diet | Audit client bundles; keep interactive islands small; defer third-party (analytics, chat) | INP |
+| Reserve space | Fixed dimensions for ad/embed/image slots; skeletons that match final layout | CLS |
+
+### 2.3 Image weight is the PK-specific battleground
+Vendor and real-wedding galleries (mehndi, barat, walima shoots) are gorgeous and *heavy*. Enforce a per-image budget, generate responsive `srcset` variants, and keep the image sitemap (`buildImagesShard`) populated so the same assets earn Google Images / Pinterest traffic — a real channel for "mehndi design"-class informational demand (head ~1.1M/mo, broad universe plausibly 1.5–3M/mo). Monitor regressions with **`lighthouse`** (Largest Contentful Paint element = image checks) and **`siteaudit`** (oversized-image flags).
+
+---
+
+## 3. Schema coverage per page type (validate via `schema-org` MCP)
+
+We already emit 12 typed JSON-LD builders from `lib/seo/jsonld.ts` (Organization, WebSite, BreadcrumbList, Article, FAQPage, HowTo, vendor/venue LocalBusiness, Review, Service, CollectionPage, plus `combineGraph()` to nest them). The mandate is **per-type coverage + continuous validation**, not new schema for its own sake.
+
+| Page type | Required schema | Builder |
+|---|---|---|
+| Vendor detail (leaf) | LocalBusiness + AggregateRating + Review + Breadcrumb | `vendorLD` / `venueLD` + `reviewLD` |
+| Vendor-type × city | CollectionPage/ItemList + Breadcrumb | `collectionPageLD` |
+| `/best/[slug]` listicle | **ItemList** (ranked) + Breadcrumb | extend `collectionPageLD` → ranked `ItemList` |
+| Pillars / cost guides | Article + FAQPage + (HowTo where stepwise) | `articleLD` + `faqLD` + `howToLD` |
+| Blog post | Article + Breadcrumb (+ FAQ if Q&A present) | `articleLD` + `faqLD` |
+| Glossary term | DefinedTerm / Article + Breadcrumb | extend `articleLD` |
+| Every page | Organization + WebSite (sitewide) + Breadcrumb | `organizationLD` + `webSiteLD` |
+
+Rules:
+- **AggregateRating must reflect real review counts** — never synthesize ratings. Honesty rule applies to markup, not just copy; fabricated `reviewCount` is a manual-action risk.
+- **FAQPage only where visible FAQ content exists** on the page (Google's policy) — and FAQ schema is our single biggest GEO lever (§5).
+- Validate **every template** with the **`schema-org` MCP (14 tools)** on each change, and spot-check live URLs in **`gsc`** Rich Results / Enhancement reports. CI step: generate → validate → fail build on schema error.
+- ItemList for listicles is the highest-ROI *new* schema work — it's what wins ranked "best X in Lahore" rich results and feeds AI list answers.
+
+---
+
+## 4. Hreflang & Urdu (en-PK / ur-PK) correctness
+
+`lib/seo/hreflang.ts` already emits `en-PK`, `ur-PK`, and `x-default` (→ English). Today Urdu is a scaffold (`/ur` single landing in the sitemap; full `/ur/` tree pending translations — see `03-url-conventions-LOCKED.md §L7`). Correctness rules as the tree fills out:
+
+- **Reciprocity**: every `en-PK` URL that declares a `ur-PK` alternate must have the Urdu URL declare the English back. One-way hreflang is silently ignored.
+- **x-default → English** (already the convention) for the international/ambiguous bucket; PK-region targeting stays via the `-PK` locale, not geo-folders.
+- **Self-reference**: each page lists *itself* among its alternates.
+- **Only sitemap Urdu URLs that actually exist and are translated** — don't emit `ur-PK` alternates pointing at untranslated/auto-translated pages (thin-content + duplicate risk). Gate the Urdu sitemap rows behind a "translation complete" flag.
+- Validate with the **`seo-hreflang` skill** and **`gsc`** International Targeting; crawl reciprocity with **`siteaudit`/`firecrawl`**. Urdu is a genuine moat vs shadiyana (English-only) — but only if implemented cleanly; broken hreflang is worse than none.
+
+---
+
+## 5. GEO — getting cited by AI Overviews, ChatGPT, Perplexity, Copilot
+
+AI engines increasingly intermediate wedding research ("best wedding photographer in Lahore under 1 lakh", "walima vs barat dress difference"). Being the *cited source* compounds brand demand the way shadiyana's venue-name navigational flywheel does. We already lead on the access layer (`robots.ts` allowlists GPTBot, OAI-SearchBot, PerplexityBot, ClaudeBot, Google-Extended, Bingbot/Copilot, Applebot, CCBot, Meta, Cohere, etc.). The content/structure layer:
+
+### 5.1 Answer-first copy
+Lead each money/info page with a 40–60 word **direct answer** (the question restated + the answer + a number/PKR figure), then expand. AI extractors and AI Overviews quote the first self-contained passage. Example: "A wedding photographer in Lahore costs roughly PKR 80,000–350,000 depending on coverage (barat-only vs full mehndi-barat-walima) and whether cinematography is included." This also wins featured snippets in classic search.
+
+### 5.2 Comparison tables & FAQ schema
+Structured, scannable blocks (vendor-vs-vendor, package tables, "barat vs walima vs mehndi dress" tables) are over-represented in AI citations. Pair every key page with a **visible FAQ + FAQPage schema** (`faqLD`) answering the real long-tail (mehndi/dholki/mayun/nikkah/rukhsati specifics, PKR ranges, Decemberistan-season booking lead times). FAQ schema is the cheapest, highest-yield GEO + rich-result lever we have.
+
+### 5.3 `llms.txt`
+Ship a root `/llms.txt` (additive static route) — a curated map of our highest-value, most-quotable pages (cost guides, vendor-type hubs, city hubs, glossary) with one-line descriptions, so LLMs can find and prefer our canonical answers. Complements (does not replace) the existing AI allowlist in `robots.ts`.
+
+### 5.4 Freshness
+AI engines and Google both privilege recency for commercial wedding queries (prices, trends, season). Keep `dateModified` honest in Article schema and `lastModified` in the sitemap; refresh cost figures and "for 2026/2027" framing on a schedule. Stale prices get dropped from AI answers.
+
+### 5.5 Third-party brand mentions
+LLM citation likelihood rises with corroborating off-site mentions (the link/PR program in `05-authority-linkbuilding.md`): reviews, listicles, local press, Reddit/forum threads. Even unlinked brand mentions feed AI association. Coordinate this with PR.
+
+### 5.6 GEO monitoring (which MCP)
+- **`serper` / `g-search`** — query target prompts, log whether an AI Overview appears and whether we're cited.
+- **`reddit` / `tavily` / `exa`** — track brand mentions and where AI engines source PK-wedding answers.
+- **`bing-webmaster`** — Bing index health = Copilot citation eligibility.
+- **`fetcher`/`playwright`** — periodically test live AI surfaces for "weddingwala" presence on our priority prompts; record share-of-citation as a KPI alongside organic traffic.
+
+---
+
+## 6. Cadence & ownership
+
+| Frequency | Task | Primary MCP |
+|---|---|---|
+| Per deploy | Schema validate (CI), URL-inspect samples, Lighthouse on changed templates, IndexNow ping new/changed URLs | `schema-org`, `gsc`, `lighthouse`, `indexnow` |
+| Weekly | GSC + Bing coverage triage, sitemap freshness/size check, CWV field glance | `gsc`, `bing-webmaster`, `crux` |
+| Monthly | Full crawl (orphans, redirects, noindex leaks, oversized images), CWV p75 by type, hreflang reciprocity, AI-citation share | `firecrawl`/`siteaudit`, `crux`/`pagespeed`, `seo-hreflang`, `serper` |
+| Quarterly | Sitemap-shard split readiness, crawl-budget audit, schema-coverage gap review vs new page types | `gsc`, `siteaudit`, `schema-org` |
+
+**Guardrail recap:** every item is additive, backward-compatible, flag-gated, and verified before flip. The fastest way to lose the traffic we build is a technical regression that quietly de-indexes a shard or tanks INP across the grid — which is exactly why monitoring, not just shipping, is half of this file.

--- a/seo-strategy/mega-plan-2yr/07-mcp-operating-manual.md
+++ b/seo-strategy/mega-plan-2yr/07-mcp-operating-manual.md
@@ -1,0 +1,111 @@
+# 07 — The MCP Operating Manual
+
+*Purpose: the day-to-day playbook for running this entire 24-month plan on the 35-server MCP stack — which server does which job, the credential boot sequence, the daily/weekly/monthly/quarterly cadences as runnable checklists, and the quota discipline that keeps a free-tier toolchain honest.*
+
+> The strategy lives in `01-traffic-model-to-1M.md` (the scenario math), `02-keyword-universe.md` (demand atlas), `04-programmatic-architecture.md` (supply at scale), and `05-authority-linkbuilding.md` (the moat). **This file is the engine room** — how the operator (available 24/7) and the assistant actually *execute* those plans with tools. The mandate from the operator was blunt: "use them 100%." Below is how.
+
+---
+
+## 1. Tool-to-Job Map (the master routing table)
+
+Every recurring job in this plan routes to a primary MCP plus a fallback. Use the primary first; fall back only on quota exhaustion, auth failure, or to cross-check a suspicious number. **Rule of one source of truth:** once GSC/GA4 are connected, *they* are truth for our own site — Ubersuggest/serper become directional context only.
+
+| Job to be done | Primary MCP → tool(s) | Fallback / cross-check |
+|---|---|---|
+| **Own search performance** (clicks, impressions, CTR, position, query mining) | `gsc` / `search-console-unified` → search-analytics; `gsc-advanced` for page×query | `ga4` (organic sessions, conversions), `bing-webmaster` |
+| **Own indexation status** | `gsc` → URL inspection; sitemap status | `bing-webmaster` index coverage |
+| **Demand research** (volume, difficulty, SERP features) | `ubersuggest` → `keyword_overview`, `keyword_metrics`, `keyword_suggestions`, `match_keywords` | `google-trends` (seasonality/Decemberistan), `serper` (live SERP truth) |
+| **Long-tail enrichment** (turning the floor into the universe) | `ubersuggest` → `match_keywords` + `keyword_metrics` (batch the leaked-out long tail); `gsc` query export | `google_suggestions`, `serper` autocomplete |
+| **Live rank / SERP position checks** | `serper` (Google PK, locId 2586) | `g-search`, `one-search`, `duckduckgo` |
+| **SERP-feature & intent classification** | `ubersuggest` → `serp_analysis`; `serper` raw SERP | `seo-sxo` skill (page-type mismatch) |
+| **Competitor profiling** (shadiyana.pk et al.) | `ubersuggest` → `domain_overview`, `domain_keywords`, `domain_top_pages`, `competitors` | `serper`, `exa` (find similar) |
+| **Competitor page crawling** (steal venue-profile structure) | `firecrawl` (JS-rendered, site map) | `fetcher`, `fetch`, `playwright`/`puppeteer` for hard JS |
+| **Backlink / authority research** | `ubersuggest` → `backlinks`, `backlinks_overview`, `linking_domains`, `anchor_texts`, `backlink_opportunity` | `bing-webmaster` inbound links; ahrefs/semrush if licensed |
+| **Technical health / Core Web Vitals (lab)** | `lighthouse`, `pagespeed` | `ubersuggest` → `pagespeed_audit` |
+| **Core Web Vitals (field data, real INP/LCP/CLS)** | `crux`, `pagespeed-crux` | `gsc` CWV report |
+| **Full-site crawl / broken links / index bloat** | `siteaudit`, `seo-audit`; `ubersuggest` → `site_audit` | `firecrawl` map + `seo-firecrawl` skill |
+| **Schema / JSON-LD validate + generate** | `schema-org` (14 tools) | `seo-schema` skill |
+| **Instant indexing on publish** | `indexnow` (submit URL set) | `gsc` Indexing API; `bing-webmaster` submit |
+| **Content / topic research** | `tavily`, `exa` (semantic), `reddit` (PK bride pain points), `wikipedia` (entity grounding) | `serper` "People Also Ask", `ubersuggest` → `content_ideas` |
+| **Visual QA of shipped pages** | `playwright` / `puppeteer` (headless CDP, device emulation) | `chrome-devtools` |
+| **Trend / seasonality calendar** | `google-trends` | `reddit`, `serper` News |
+
+Cross-reference the skill layer too: `seo-google` wraps GSC/PSI/CrUX/Indexing API; `seo-bing` wraps Bing + IndexNow; `seo-backlinks`/`seo-ahrefs` for link gap; `seo-cluster` for SERP-overlap clustering feeding `02-keyword-universe.md`; `seo-programmatic` for the `04` page engine; `seo-drift` to baseline on-page SEO before/after each deploy (critical on a live site — see `feedback_live_system_safety`).
+
+---
+
+## 2. STEP ZERO — Credential Boot Sequence (do this before anything else)
+
+We are flying blind until our own data is wired. Ubersuggest's PK free tier leaks US data and undercounts the long tail; every number in `01`/`02` is labelled *directional* for exactly this reason. The single highest-ROI action this week is connecting Google's truth. Follow `GSC-GA4-SETUP.md` and execute in this order:
+
+| Order | Connect | Why it's the priority it is | Unlocks |
+|---|---|---|---|
+| **0a** | **GSC** (service-account JSON; verify property `https://www.weddingwala.pk`) | The only source of *our* real queries, positions, impressions, CTR — replaces directional Ubersuggest data and powers weekly rank tracking & monthly query mining | Real keyword universe, indexation truth, CWV report |
+| **0b** | **GA4** (property + Measurement/API access) | Ties traffic to *behaviour* — which of the 1M is bookings/leads vs vanity informational (the honesty rule in `01`) | Conversion attribution, landing-page value, engaged sessions |
+| **0c** | **Bing Webmaster** | Bing index feeds **Microsoft Copilot citations**; also a second free backlink dataset and second IndexNow channel | Copilot/AI visibility, free inbound-link data, redundancy |
+
+Verify each with a single read before trusting it: `gsc` list-sites, `ga4` run a 7-day organic-sessions report, `bing-webmaster` site list. **Do not begin weekly cadences until 0a and 0b return live data.** Until then, mark every KPI in reports as "(directional — pre-GSC)".
+
+---
+
+## 3. Operating Cadences (runnable checklists)
+
+The operator is 24/7; the assistant drives the tools. These are checklists, not prose — run them top to bottom and log results into the monthly KPI sheet.
+
+### DAILY — index & rank pulse (~10 min, low quota)
+- [ ] **New URLs published yesterday?** → `indexnow` submit the URL set; mirror via `gsc` Indexing API and `bing-webmaster` submit.
+- [ ] **Index check** on the 3–5 newest priority URLs → `gsc` URL inspection (indexed? canonical correct? mobile usable?).
+- [ ] **Money-keyword pulse** — spot-check 5 rotating commercial terms live → `serper` (PK, locId 2586): e.g. `walima dress for bride`, `marriage hall near me`, `pakistani bridal dresses`, plus one `{vendor}×{city}` and one venue-name navigational term.
+- [ ] **Deploy guard** — if a deploy shipped, run `seo-drift` diff on touched templates to confirm titles/canonicals/hreflang/JSON-LD didn't regress (live-prod safety, `05` depends on these pages ranking).
+- [ ] Log anomalies (sudden position drop, deindex) → escalate to weekly technical scan.
+
+### WEEKLY — rank, mining, technical, competitor (~60–90 min)
+- [ ] **Rank tracking** → `gsc` Search Analytics, last 7d vs prior 7d: top movers up/down by query and by page. Annotate causes.
+- [ ] **New-keyword mining** → pull `gsc` queries at positions 5–20 with impressions but low CTR (these are "almost there" — the fastest wins). Feed candidates into `ubersuggest` `keyword_metrics` to score, route to `02-keyword-universe.md` backlog.
+- [ ] **Long-tail enrichment batch** → take one cluster (e.g. mehndi-by-body-part, bridal-dress-by-occasion) → `ubersuggest` `match_keywords` + `keyword_metrics` to convert the ~19-enriched floor into a fuller list. (Respect the 3-report/day cap — see §4.)
+- [ ] **Technical scan** → `lighthouse` + `pagespeed-crux` on the 5 highest-traffic templates (home, one `{vendor}×{city}`, one venue profile, one mehndi pillar, one bridal-dress page). Flag INP/LCP/CLS regressions.
+- [ ] **Competitor watch** → `ubersuggest` `domain_top_pages` on shadiyana.pk (their non-venue gaps are our opening); `firecrawl` one new competitor profile page to study structure; `serper` check who's newly ranking on 3 contested terms.
+- [ ] **Content research feed** → `reddit` + `tavily` scan for fresh PK bride questions (dholki, mayun logistics, barat budgets) → content-engine backlog.
+
+### MONTHLY — full audit, gaps, links, KPI report (~half day)
+- [ ] **Full site audit** → `siteaudit` / `seo-audit` (or `ubersuggest` `site_audit` → `site_audit_status` → `site_audit_pages`): crawl errors, broken links, duplicate titles, thin/orphan pages, **index-bloat** check on programmatic combos (auto-filtered empties must stay noindexed — see `04`).
+- [ ] **Content-gap analysis** → `ubersuggest` `competitors` + `domain_keywords` (shadiyana & 2 others) minus our ranked set = gap list; cluster via `seo-cluster`; prioritize SD≤20 commercial first (bridal-dress occasion wins remain fastest ROI).
+- [ ] **Backlink review** → `ubersuggest` `backlinks_overview`, `linking_domains`, `anchor_texts`, `backlink_opportunity`; cross-check `bing-webmaster` inbound. Track RD count vs the DA-35 trajectory in `05`. Watch for toxic/spam anchors.
+- [ ] **Schema sweep** → `schema-org` validate JSON-LD on each page type (Organization, LocalBusiness, AggregateRating, Article, FAQPage, BreadcrumbList) — additive only.
+- [ ] **AI-visibility check** → does Copilot (`bing-webmaster` index) / `serper` AI Overview cite us for any term? Note GEO progress (`seo-geo`).
+- [ ] **KPI REPORT** (truth from `gsc`+`ga4`, never Ubersuggest): organic clicks, impressions, indexed pages, avg position on the priority basket, organic sessions, **leads/bookings conversions**, RD count. Plot against Conservative/Base/Aggressive curves in `01`. Call out honestly how much growth is low-value informational vs commercial.
+
+### QUARTERLY — strategy review & content refresh (~1–2 days)
+- [ ] **Scenario re-forecast** → update `01` model with 3 months of real GSC data; is the curve tracking Base or slipping below Conservative? Adjust page-build pace and link targets accordingly.
+- [ ] **Content refresh / pruning** → `gsc` find decaying pages (lost clicks QoQ) → refresh, re-date, re-submit via `indexnow`. Identify dead-weight thin pages to consolidate (protects crawl budget; `seo-programmatic`).
+- [ ] **Seasonality prep** → `google-trends` map the next quarter (Decemberistan wedding-season surge for venues/photographers/bridal-wear) → pre-build & pre-index inventory 8–10 weeks ahead.
+- [ ] **Link campaign reset** → review `05` tactics against actual RD growth; reallocate outreach to what's converting.
+- [ ] **Tooling/quota review** → has volume outgrown free Ubersuggest? Decide on a paid upgrade (§4).
+
+---
+
+## 4. Quota Discipline & Paid-Upgrade Triggers
+
+Ubersuggest free tier = **3 domain reports/day** and only ~19 enriched keywords per suggestion call. This is the binding constraint, so spend it deliberately:
+
+- **Budget the 3 daily domain reports** like cash: typically 1 on us, 1 on shadiyana.pk, 1 rotating among tier-2 competitors. Don't burn them on idle curiosity.
+- **Enrichment ≠ domain reports** — `keyword_metrics` / `match_keywords` enrich keyword lists and are the workhorses for converting the directional floor into the universe; batch them and cache every result into `02-keyword-universe.md` so you never re-query the same term.
+- **GSC has no such cap** — once connected (§2), prefer GSC query/page exports over Ubersuggest for anything about our own site. This alone removes most quota pressure.
+- **serper/firecrawl/apify** have validated keys — watch credit burn; cache SERP and crawl snapshots; don't re-crawl unchanged competitor pages weekly (monthly is enough).
+- **Cache everything.** Every enriched keyword, SERP snapshot, and competitor crawl is written once to the strategy docs / a data file and reused. Re-querying is the most common quota waste.
+
+**When to pay (and what it unlocks):**
+
+| Trigger | Upgrade | Unlocks |
+|---|---|---|
+| Long-tail enrichment is bottlenecking the page engine (need thousands of scored kw fast) | **DataForSEO** (`seo-dataforseo`) | Live volume/difficulty/intent at scale, image SERP, programmatic SERP pulls, AI-visibility scraping — best $/keyword for `04` |
+| Backlink moat (`05`) needs a real RD/anchor dataset beyond Ubersuggest+Bing | **Ahrefs** (`seo-ahrefs`) or **Semrush** | Full referring-domain history, link-gap vs shadiyana, content explorer |
+| AI Share-of-Voice across ChatGPT/Gemini/Perplexity/AI Overviews/AI Mode becomes a KPI | **SE Ranking** (`seo-seranking`) / **Profound** (`seo-profound`) | Multi-engine AI citation tracking in one call |
+
+Until a trigger fires, the free stack (GSC + GA4 + Bing + Ubersuggest free + serper/firecrawl + the technical/schema servers) is **sufficient to run this plan** — paid tools accelerate, they don't gate.
+
+---
+
+## 5. The 24/7 Operating Loop (how operator + assistant split the work)
+
+The operator authenticates servers, approves deploys/outreach, and supplies judgment on PK nuance; the assistant runs the checklists, queries the MCPs, scores keywords, drafts schema, and writes findings back into these strategy files. The contract: **assistant proposes from data, operator disposes; every site change stays additive, flag-gated, and zero-downtime** (`feedback_live_system_safety`). Run DAILY autonomously, surface WEEKLY for review, present MONTHLY/QUARTERLY as decisions. That cadence — real Google data in, prioritized SD≤20 commercial pages out, indexed instantly, measured honestly against `01`'s scenarios — is how the 35-server stack gets used 100%.

--- a/seo-strategy/mega-plan-2yr/08-24-month-roadmap.md
+++ b/seo-strategy/mega-plan-2yr/08-24-month-roadmap.md
@@ -1,0 +1,167 @@
+# 08 — The 24-Month Month-by-Month Execution Roadmap
+
+*Purpose: a calendarised, KPI-gated execution plan that extends `SEO-MASTER-PLAN.md` (its 3 phases stop at M12) to a full 24 months, mapping every month to a focus, concrete deliverables, the MCP servers that drive the work, and an exit-gate KPI tied to the Base scenario in `01-traffic-model-to-1M.md`.*
+
+> **How to read this.** Traffic milestones below track the **Base scenario** (`01` §2.3): the defensible plan-of-record landing at ~500k/mo by M24. The Aggressive (1M ceiling) line is noted only as the upside we architect toward — never as a forecast. All page counts are cumulative *quality-indexed* pages (empty `{vendor}×{city}` combos stay `noindex`; see `04-programmatic-architecture.md`). Every number is **directional until GSC is connected at M0** and re-forecast each quarter. Keyword data references `02-keyword-universe.md`; link targets reference `05-authority-linkbuilding.md`. Decemberistan = the Oct–Feb PK wedding peak that bends every seasonal lever.
+
+---
+
+## 1. Phase map (extends the master plan's 3 phases to 6)
+
+| Phase | Months | Theme | Base exit-traffic |
+|---|---|---|---|
+| **P0 Foundation** | M1 | Data truth + technical baseline | impressions live in GSC |
+| **P1 Quick-wins + flywheel** | M2–M3 | Tier-A bridal-dress wins + vendor-name navigational engine | **~4,000/mo** |
+| **P2 Category + geo depth** | M4–M6 | Tier-2 cities, under-served categories, Urdu, event pages | **~25,000/mo** |
+| **P3 Authority + content scale** | M7–M12 | Decemberistan report, listicle scale, link velocity, head-term entry | **~150,000/mo** |
+| **P4 Head-terms + moat + informational scale** | M13–M18 | Mehndi/dress gallery mass, comparison moat, DA-30 push | **~320,000/mo** |
+| **P5 Category leadership + 1M push** | M19–M24 | Full universe coverage, brand demand, refresh/defend | **~500,000/mo (1M ceiling architected)** |
+
+---
+
+## 2. P0 — Foundation (M1)
+
+**Primary focus:** replace directional Ubersuggest data with Google truth; lock the technical floor before scaling pages.
+
+| Item | Detail |
+|---|---|
+| Deliverables | Connect **GSC + GA4 + Bing Webmaster** (`GSC-GA4-SETUP.md`); submit all 4 sitemap shards; baseline indexation + impressions; full schema audit; `noindex` sweep on thin/empty programmatic combos; CWV baseline; IndexNow wired. ~0 net-new pages — fix, don't add. |
+| MCPs | **gsc / ga4 / bing-webmaster** (step zero), **siteaudit / seo-audit / lighthouse / pagespeed / crux** (technical baseline), **schema-org** (validate JSON-LD), **indexnow** (submit), **ubersuggest** (`site_audit`, `validate_site`). |
+| **Exit gate** | GSC verified + receiving impressions; ≥90% of existing money pages indexed; CWV green on templates; baseline KPI snapshot recorded. **If GSC not connected by end-M1 → halt all content spend until it is** (you are flying blind otherwise). |
+
+---
+
+## 3. P1 — Quick-wins + flywheel (M2–M3) → Base ~4,000/mo
+
+The fastest ROI lives in the bridal-dress *occasion* cluster (~52% of scored volume at SD ≤ 20) and the vendor-name navigational flywheel that shadiyana proves works.
+
+### M2 — Bridal-dress quick wins + GBP
+- **Deliverables:** publish ~12 bridal-dress occasion pages targeting the SD≤12 set — "walima dress for bride" (6,600/SD7), "bridal dresses for barat" (4,400/SD8), "nikkah dresses for bride" (3,600/SD8), "mehndi dress for bride" (4,400/SD9), "pakistani wedding dress for bride" (8,100/SD12); deepen ~150 vendor profile pages (unique data, photos, PKR ranges); Google Business Profile live + first 10 citations (`05` §3). Links target: **+10 referring domains**.
+- **MCPs:** **ubersuggest** (`keyword_metrics`/`match_keywords` to enrich the long tail beyond the ~19-row floor), **serper** (live SERP for each target), **schema-org** (Product/FAQ), **firecrawl** (competitor profile teardown), **indexnow**.
+- **Exit gate:** first Tier-A keywords entering page 2–3; first GSC clicks; ~25 referring domains cumulative.
+
+### M3 — "Best {vendor} in {city}" listicle sprint
+- **Deliverables:** publish the **24 "Best {vendor} in {city} 2026"** listicles (6 core vendors × 4 Tier-1 cities) — **only city×vendor cells with ≥3 vendors (per `04` thresholds); backfill the rest as inventory grows** — answer-first, ItemList + FAQPage schema, PKR ranges, comparison tables (the GEO/AI-citation weapon); ship the cost pillar + budget calculator push. Cumulative ~**400 indexed pages**.
+- **MCPs:** **serper / exa** (SERP + entity research), **schema-org**, **g-search**, **ubersuggest** (`serp_analysis`, `content_ideas`), **indexnow**.
+- **Exit gate (quarter):** **~4,000 visitors/mo**, ~25 referring domains, first page-1 rankings on Tier-A bridal-dress terms, DA ~6. **If <2,000/mo by M3 → audit indexation (crawl budget) before adding pages.**
+
+---
+
+## 4. P2 — Category + geo depth (M4–M6) → Base ~25,000/mo
+
+Attack shadiyana's weak surface: non-venue categories, Tier-2 cities, Urdu, and PK event pages.
+
+### M4 — Tier-2 city rollout
+- **Deliverables:** activate Tier-2 cities (Faisalabad, Multan, Sialkot, Gujranwala, Peshawar) across the 11 vendor types where inventory exists; ~120 new `{vendor}×{city}` + profile pages; expand bridal-dress cluster (gharara 6,600/SD20, nikkah dresses 6,600/SD21). Links: **+15 RDs**.
+- **MCPs:** **ubersuggest** (`keyword_suggestions` + enrichment per city), **serper**, **gsc** (mine Search Analytics for emerging queries to prioritise), **indexnow**.
+- **Exit gate:** Tier-2 pages indexed and impressing; ~60 RDs cumulative.
+
+### M5 — Under-served categories + event pages
+- **Deliverables:** deepen photographers/makeup/catering/mehndi/decor (where shadiyana is thin); publish PK event pages (mayun, dholki, barat, walima, nikkah, rukhsati) as informational→money internal-link hubs; launch venue navigational pages (marquee/banquet names, e.g. "marriage hall near me" 4,400). ~150 new pages.
+- **MCPs:** **reddit / tavily** (real PK couple language for event pages), **serper**, **schema-org** (Event/LocalBusiness), **firecrawl**.
+- **Exit gate:** multiple #1–3 on Tier-A/B; event pages feeding internal link equity.
+
+### M6 — Urdu layer + real-wedding PR start
+- **Deliverables:** expand **ur-PK** hreflang coverage on top money pages (already scaffolded); first real-wedding features that credit vendors (link-bait, `05` §5b); cumulative ~**900 indexed pages**. Links: **+20 RDs → ~60 total**.
+- **MCPs:** **gsc** (quarterly re-forecast vs model), **ahrefs/semrush** optional RD check, **ubersuggest** (`backlinks_overview`), **schema-org**, **bing-webmaster**.
+- **Exit gate (quarter):** **~25,000 visitors/mo**, ~60 RDs, DA ~11 (secondary, directional), multiple top-3 commercial terms. **If <12,000/mo by M6 → pivot budget from new pages to link-building (RD growth is the gate, per `01` §4.2; DA is a secondary directional signal); if informational CTR is far below model, down-revise the Aggressive line, not the plan.**
+
+---
+
+## 5. P3 — Authority + content scale (M7–M12) → Base ~150,000/mo
+
+This is where DA must climb from ~11 to ~20 and content velocity ramps toward the 8k-page trajectory. Decemberistan (Oct–Feb) is the seasonal demand spike to ride.
+
+### M7 — Listicle scale-out
+- **Deliverables:** extend "Best {vendor} in {city}" to all 12 cities × core vendors (~80+ listicles total); begin systematic mehndi gallery pilot (10 posts, e.g. "back hand design mehndi" 33,100/SD14 — the best low-diff informational win). ~250 new pages.
+- **MCPs:** **serper / exa**, **schema-org**, **ubersuggest** (`estimate_serp_clicks`), **firecrawl**, **indexnow**.
+- **Exit gate:** listicles ranking + AI-cited; mehndi pilot indexed.
+
+### M8 — Cost/budget pillar expansion + HARO
+- **Deliverables:** city-level cost variants ("{vendor} cost {city}", "wedding cost in pakistan") — the most-linkable, snippet-prone format; start HARO/journalist reactive outreach (`05` §7). ~150 pages. Links: **+25 RDs**.
+- **MCPs:** **tavily / exa** (journalist queries), **serper**, **schema-org** (FAQ/HowTo), **gsc**.
+- **Exit gate:** featured snippets captured on cost terms; ~120 RDs cumulative.
+
+### M9 — Mehndi/informational scale begins
+- **Deliverables:** scale mehndi cluster (by body-part/style/occasion/year) to ~60 galleries with image-SEO discipline (alt text, image sitemap already shipped); guest content + photographer partnerships (`05` §6). Cumulative ~**1,600 pages**.
+- **MCPs:** **ubersuggest** (enrich mehndi long-tail — it's a FLOOR until enriched), **serper**, **firecrawl**, **schema-org** (ImageObject), **indexnow**.
+- **Exit gate (quarter):** **~70,000 visitors/mo**, ~120 RDs, DA ~16 (secondary, directional). **If informational galleries aren't earning blue-link clicks (Pinterest/Images dominance, `01` §4.2), treat them as assist-only and reweight effort to commercial pages.**
+
+### M10–M11 — Decemberistan report + peak season
+- **Deliverables:** publish the annual **"Pakistan Wedding Season Report"** (hero link-magnet, `05` §5a) — original PK data for PR pickup; ride Decemberistan demand with seasonal landing pages and refreshed listicles; comparison pages (`/compare`) begin. ~300 pages over the two months. Links: **+50 RDs across the report push**.
+- **MCPs:** **ga4 / ga** (own booking data for the report), **tavily / exa / reddit** (PR targets), **serper**, **schema-org** (Dataset/Article), **firecrawl**.
+- **Exit gate:** report earns 20+ RDs; peak-season traffic spike captured.
+
+### M12 — Head-term entry + Year-1 audit
+- **Deliverables:** begin contested head terms now that DA supports it ("pakistani bridal dresses" 8,100/SD20, "bridal gown dress" 14,800/SD20); full Year-1 technical re-audit; cumulative ~**2,300 pages**. Links: **~180 RDs total**.
+- **MCPs:** **gsc / ga4** (annual re-forecast), **siteaudit / lighthouse / crux**, **ubersuggest** (`domain_overview`), **schema-org**, **bing-webmaster**.
+- **Exit gate (quarter):** **~150,000 visitors/mo** (surpasses shadiyana's ~66k by ~2.3×), ~180 RDs, DA ~20 (secondary, directional). **If RD growth stalls <150 → links become the #1 priority for H2; the model caps near Base-low otherwise (DA <15 is a corroborating signal, not the gate).**
+
+---
+
+## 6. P4 — Head-terms + moat + informational scale (M13–M18) → Base ~320,000/mo
+
+### M13–M14 — Informational gallery mass
+- **Deliverables:** scale mehndi + dress-idea + decor-idea + hairstyle galleries toward several hundred (the volume mass that makes 1M arithmetically conceivable); systematic internal-link from galleries → money pages. ~600 pages. Links: **+40 RDs**.
+- **MCPs:** **ubersuggest** (`keyword_metrics` mass-enrichment), **serper**, **firecrawl**, **schema-org**, **indexnow**.
+- **Exit gate:** gallery cluster indexed at scale; index bloat controlled (noindex thin).
+
+### M15–M16 — Comparison moat + vendor reciprocity engine
+- **Deliverables:** build out comparison/alternatives pages as a defensible moat; formalise the vendor-reciprocity link engine (`05` §4) as a permanent function (scalable RDs); refresh all M1–M6 pages. ~500 pages. Links: **+60 RDs**.
+- **MCPs:** **serper / exa**, **gsc** (decay detection), **schema-org**, **ahrefs/semrush** optional gap check.
+- **Exit gate:** ~280 RDs cumulative; refreshed pages regaining/holding position.
+
+### M17–M18 — DA-30 push + Decemberistan #2
+- **Deliverables:** second annual Wedding Season Report (now with a year of authority behind it → bigger pickup); styled-shoot/trend pitches to wedding media (`05` §5c); cumulative ~**3,200 pages**. Links: **~280 → on track for 450**.
+- **MCPs:** **ga4** (report data), **tavily / exa / reddit**, **serper**, **schema-org**, **indexnow**.
+- **Exit gate (quarter):** **~320,000 visitors/mo**, ~280 RDs, DA ~25 (secondary, directional), avg commercial position 8–12. **If RD growth plateaus <250 → escalate digital PR; referring-domain growth is the single hardest variable and the binding gate (`01` §4.1); DA tracks it only directionally.**
+
+---
+
+## 7. P5 — Category leadership + 1M push (M19–M24) → Base ~500,000/mo
+
+Final phase: complete universe coverage, convert authority into head-term dominance, and build brand/direct-nav demand. The 1M ceiling is *architected* here — captured only if links, velocity, and image-SERP capture all break our way (`01` §4).
+
+### M19–M20 — Full universe coverage
+- **Deliverables:** close remaining `{vendor}×{city}` + long-tail gaps; complete mehndi/dress/decor informational universe; full Urdu parity on commercial pages. ~700 pages. Links: **+50 RDs**.
+- **MCPs:** **ubersuggest** (final long-tail enrichment), **gsc** (query-gap mining), **serper**, **schema-org**, **indexnow**.
+- **Exit gate:** ~480 RDs; category breadth matching/exceeding shadiyana across all verticals.
+
+### M21–M22 — Head-term dominance + brand demand
+- **Deliverables:** push contested head terms to top-3 on the strength of DA ~30+; brand campaigns to grow "weddingwala" direct-nav (the ~5% high-value slice, `01` §3); systematic content refresh of all pillars. ~500 pages. Links: **+60 RDs**.
+- **MCPs:** **gsc / ga4** (brand-query tracking), **google-trends** (brand demand), **serper**, **schema-org**.
+- **Exit gate:** brand search rising; head terms in top-3; ~540 RDs.
+
+### M23 — Decemberistan #3 + defend
+- **Deliverables:** third Wedding Season Report; defend/refresh every winning page ahead of peak; squeeze conversion on the ~400k commercial slice (listicles + money + cost + brand) — leads are the north star. ~300 pages.
+- **MCPs:** **ga4** (lead funnel), **gsc** (decay), **tavily/exa** (PR), **lighthouse/crux** (CWV defense), **schema-org**.
+- **Exit gate:** peak captured; commercial-slice leads up QoQ.
+
+### M24 — Year-2 close + re-forecast
+- **Deliverables:** cumulative ~**4,000 quality-indexed pages**; full technical + content audit; Year-3 plan seeded; honest model re-forecast vs actuals. Links: **~350 RDs total**.
+- **MCPs:** **gsc / ga4 / bing-webmaster** (final truth), **siteaudit / lighthouse / crux**, **ubersuggest** (`domain_overview`), **schema-org**.
+- **Exit gate (quarter / endgame):** **Base ~500,000 visitors/mo** (~200k of it commercially valuable), ~350 RDs, DA ~28, avg commercial position 7–11. **Aggressive ceiling = 1M @ ~8,000 pages / DA 35+ / 600+ RDs** — report it only beside the lead number, never alone.
+
+---
+
+## 8. Quarterly milestone summary (Base scenario, plan-of-record — directional, re-forecast quarterly once GSC connected)
+
+> Visitor figures below are **modeled milestones, not commitments** — they are directional until GSC is connected (M0) and must be re-forecast each quarter against real GA4/GSC data.
+
+| Quarter | Month | Pages | Ref. domains | DA (secondary) | **Visitors/mo (modeled, directional)** | Headline gate |
+|---|---|---|---|---|---|---|
+| Q1 | M3 | ~400 | ~25 | ~6 | **4,000** | Tier-A page-1; GSC live |
+| Q2 | M6 | ~900 | ~60 | ~11 | **25,000** | Multiple top-3; pivot to links if <12k |
+| Q3 | M9 | ~1,600 | ~120 | ~16 | **70,000** | Mehndi scale; informational CTR validated |
+| Q4 | M12 | ~2,300 | ~180 | ~20 | **150,000** | Beat shadiyana; RD gate at 150 (DA ~15 directional) |
+| Q6 | M18 | ~3,200 | ~280 | ~25 | **320,000** | Comparison moat; PR escalation if RDs <250 |
+| Q8 | M24 | ~4,000 | ~350 | ~28 | **500,000** | Category leadership; 1M only as architected ceiling |
+
+---
+
+## 9. Standing decision-gates (apply every quarter)
+
+1. **No GSC, no scale** — if real Google data isn't flowing, stop adding pages and fix that first (`01` §4.1).
+2. **RD gating** — if referring-domain growth falls behind the curve in `05` §2, reallocate from new pages to link-building; commercial positions don't materialise without authority. (DA is a secondary, directional check on the same trend — never the trigger.)
+3. **Informational reality check** — if mehndi/dress gallery blue-link CTR is far below the 1–4% model assumption (Pinterest/Images carousels), down-revise the Aggressive line and treat galleries as assist-only — do **not** defend the 1M number against contrary GSC data.
+4. **Leads over vanity** — if forced to choose, fund the ~400k commercial slice (listicles + money + cost + brand) over raw informational volume. Re-forecast the whole model against actuals every quarter.

--- a/seo-strategy/mega-plan-2yr/09-measurement-cadence.md
+++ b/seo-strategy/mega-plan-2yr/09-measurement-cadence.md
@@ -1,0 +1,138 @@
+# 09 — Measurement, KPIs & Operating Cadence
+
+*Purpose: the scoreboard and the routine that runs it — a north-star-down KPI tree, the GSC + GA4 + Bing data pipeline (pulled via MCP), a Looker Studio dashboard spec built on native connectors, and a weekly/monthly/quarterly review rhythm calibrated so early no-traffic months are judged on leading indicators, not vanity visitors.*
+
+> **Read this first.** A plan you cannot measure is a wish. This file does not re-argue the 1M ceiling (see `01-traffic-model-to-1M.md`) — it tells you *what to count, where it comes from, and when to look.* The hard rule from `01`: the north star is **organic leads/bookings**, not the 1M visitor number. Much of any 1M is low-value mehndi-design / dress-inspiration informational traffic (see `02-keyword-universe.md`); the money is in a small commercial subset (venues, photographers, bridal dress). We measure both, but we **judge** the program on the commercial subset. All Ubersuggest figures here are **directional**; GSC is truth — connect it first (`GSC-GA4-SETUP.md`).
+
+---
+
+## 1. The KPI tree (north-star down)
+
+One north star, three lagging business outcomes, and a layer of leading indicators that move *first*. Read it top-down for "are we winning?" and bottom-up for "what do I fix this week?"
+
+```
+NORTH STAR:  Organic leads & bookings  (vendor enquiries / contact-reveals from organic)
+   │
+   ├─ LAGGING (outcomes, move late)
+   │    • Organic sessions (total) — vanity ceiling, watched not chased
+   │    • Commercial-intent organic sessions (venue/photographer/dress/makeup)
+   │    • Organic conversion rate (lead ÷ commercial session)
+   │    • Assisted conversions + informational→commercial internal-bridge CTR
+   │        (the metric that *justifies* chasing informational traffic — see 10-resourcing-conversion-risk.md §2.3)
+   │    • Keywords ranking top-3 / top-10  (commercial cohort tracked separately)
+   │
+   ├─ MID (move mid-cycle)
+   │    • GSC clicks  ←  CTR  ←  impressions   (the funnel, in this order)
+   │    • Indexed-page count (valid ÷ submitted)  & index-bloat ratio
+   │    • Referring domains / DA  (see 05-authority-linkbuilding.md §10)
+   │
+   └─ LEADING (move first — judge early months on these)
+        • Pages published / indexed this week
+        • Impressions on new URLs (demand confirmed before clicks exist)
+        • New referring domains won
+        • CWV pass rate (% URLs "Good")
+        • AI-citation share (mentions in AI Overviews / ChatGPT / Perplexity / Copilot)
+```
+
+### KPI definitions & targets
+
+> **Data-label note.** Two distinct classes of target appear below. **Off-site authority figures (DA, referring domains) are *directional* (Ubersuggest free-tier — rough).** All lead/conversion-rate and impressions/clicks/CTR/sessions ranges are **modeled/illustrative — to be set from the GA4 baseline** once GSC/GA4 are connected; they are forecasts with no external source yet, not promises. Once GSC/GA4/Bing are live, both classes are replaced by **real** numbers.
+
+| KPI | Layer | Source | M3 target | M12 target | M24 target |
+|---|---|---|---|---|---|
+| Organic leads/bookings (mo) | North star | GA4 conversion event | 5–15 | 200–500 | 1,500–4,000 |
+| Organic sessions (mo) | Lagging | GA4 / GSC clicks | 1–3k | 60–120k | 400k–1M |
+| Commercial-intent sessions % | Lagging | GA4 landing-page segment | n/a | 12–18% | 10–15% |
+| Organic conv. rate (commercial) | Lagging | GA4 | baseline | 1.5–3% | 2–4% |
+| Info→commercial bridge CTR + assisted conv. | Lagging | GA4 (path/assisted-conv) | baseline | 3–6% | 5–10% |
+| Keywords top-3 / top-10 | Lagging | GSC position | ~0 / ~10 | 150 / 1,200 | 1,500 / 12,000 |
+| GSC clicks (mo) | Mid | GSC | 200–800 | 50–100k | 350k–900k |
+| GSC impressions (mo) | Mid | GSC | 30–80k | 3–6M | 25–60M |
+| Sitewide CTR | Mid | GSC | 0.5–1.5% | 1.5–2.5% | 1.5–3% |
+| Quality-indexed pages | Mid | GSC Pages report | 300–800 | ~4k (Base) | ~8k (Aggressive) |
+| Raw indexed (valid, incl. thin) | Mid | GSC Pages report | 300–800 | 5–9k | 20–40k (crawlable/generated capacity incl. noindex — NOT an indexed-page target) |
+| Referring domains | Mid | Ubersuggest / Bing | 15–30 | 150–250 | 600–900 |
+| DA | Mid | Ubersuggest | 3–6 | 18–25 | 35+ |
+| CWV pass rate | Leading | CrUX / PageSpeed | 70%+ | 90%+ | 90%+ |
+| AI-citation share | Leading | serper / manual probes | track | growing | category-leader |
+
+Targets are the **base scenario** from `01`; conservative and aggressive bands live there. Never present a single number as a promise.
+
+---
+
+## 2. The data pipeline (own-data first, MCP-driven)
+
+The pipeline is **own-data first**: GSC, GA4 and Bing Webmaster are ground truth and cost nothing. Ubersuggest/serper/CrUX fill the gaps (DA, competitor RDs, AI-citation probes). The operator is available 24/7, so collection is *pull-on-demand via MCP*, not a brittle scheduled ETL.
+
+| Stage | Source | MCP server | What it answers |
+|---|---|---|---|
+| Demand & rank truth | Search Console | `gsc` / `gsc-advanced` / `search-console-unified` | impressions, clicks, CTR, position, by query/page/country/device |
+| Behaviour & leads | GA4 | `ga4` | organic sessions, landing pages, conversions, lead events |
+| Microsoft / Copilot index | Bing Webmaster | `bing-webmaster` | Bing impressions/clicks, backlinks, IndexNow status |
+| Indexation push | IndexNow | `indexnow` | instant submit of new/changed URLs |
+| CWV field data | CrUX | `crux` / `pagespeed-crux` / `pagespeed` | LCP/INP/CLS pass rate (field, not lab) |
+| Off-site authority | Ubersuggest | `ubersuggest` | DA, referring domains, competitor backlink gap |
+| AI-citation share | serper + probes | `serper` / `tavily` / `exa` | does WW appear in AI Overviews / LLM answers |
+| Competitor watch | Ubersuggest / serper | `ubersuggest` / `serper` | shadiyana.pk RDs (~850), keyword overlap, new venue pages |
+
+**Flow:** GSC/GA4/Bing → MCP pull → reconcile against last week's snapshot → diff into *winners/losers* → write commentary → file actions into the relevant plan doc (content gaps → `02`, link gaps → `05`, template/CWV issues → `04`). The assistant's job each cycle is to turn the diff into a *decision*, not just a chart.
+
+**STEP ZERO gate:** until GSC, GA4 and Bing are connected and verified (`GSC-GA4-SETUP.md`), every number in this plan is Ubersuggest-directional. Connecting them is the single highest-leverage measurement task — do it before publishing page #2.
+
+---
+
+## 3. Looker Studio dashboard spec
+
+There is **no Looker Studio MCP or public build API** — dashboards are built once, by hand, on Looker Studio's **native GA4 and GSC connectors** (free, official, auto-refreshing). The assistant cannot edit the dashboard, so it pulls the *same numbers* via MCP (§2) for the written commentary that sits beside it. The dashboard is the operator's at-a-glance; the MCP pull is the analysis.
+
+**Data sources to attach:** (1) GA4 native connector → WW property; (2) GSC connector twice — once "Site Impression" (totals) and once "URL Impression" (per-page); (3) optional Sheet of monthly DA/RD pulled from Ubersuggest, since there's no Looker connector for it.
+
+**Page 1 — Executive scorecard.** Scorecards (with sparkline + period-over-period %): organic sessions, GSC clicks, impressions, CTR, organic leads, top-3 keyword count. One time-series: organic clicks vs impressions (dual axis) over 16 months. A single "leads" big-number tile so the north star is impossible to miss.
+
+**Page 2 — Traffic & query trend.** Clicks/impressions trend with a 7-day moving average; query table sorted by clicks with position + CTR columns; a **winners/losers** table — biggest click delta vs prior period, both directions (this is the weekly action list). Filter controls: country (default PK), device, date.
+
+**Page 3 — Landing-page & city×vendor performance.** Top landing pages by clicks/impressions/position. A pivot of **city × vendor-type** (the programmatic surface from `04`: 11 vendor types × 12 cities) showing clicks per cell — instantly reveals which Lahore-venues / Karachi-photographers cells are pulling and which are dead. A "rising pages" table filtered to URLs gaining impressions but with position >10 (the optimisation backlog).
+
+**Page 4 — Conversions & leads.** GA4 organic conversions over time; lead conversion rate by landing-page group (venue vs photographer vs dress vs informational); commercial-vs-informational session split (proves the §1 quality argument); top converting cities/vendor types.
+
+**Page 5 — Technical / CWV.** CWV pass-rate gauges (LCP/INP/CLS) from a CrUX Sheet; indexed vs submitted pages; coverage-error count; index-bloat ratio. GSC's own Core Web Vitals + Indexing reports are the backstop here.
+
+Every Looker tile has a named MCP equivalent in §2, so weekly commentary and the dashboard never disagree.
+
+---
+
+## 4. Review rhythm (operator available 24/7)
+
+> **Canonical cadence lives in `07-mcp-operating-manual.md` §3.** That file owns the operating cadence (weekly/monthly/quarterly loops + MCP usage + Step-Zero). The loops below are the *measurement view* of that same rhythm — what to count in each loop — not a second, parallel cadence. If the two ever diverge, `07` §3 wins.
+
+Three loops at three altitudes. Discipline beats intensity — the same checklist every cycle.
+
+### Weekly scorecard (Mondays, ~30 min)
+Pull GSC (clicks/impressions/CTR/position, last 7d vs prior 7d via `gsc`), GA4 leads (`ga4`), Bing (`bing-webmaster`), new RDs (`ubersuggest`/Bing). Produce a one-screen scorecard: north-star leads, the funnel (impr→clicks→CTR), pages published/indexed, new RDs, and the **winners/losers** query list. Action: pick the top 3 movers and route them — new-page-with-impressions-no-clicks → title/meta or CTR fix; rising-but-rank-11–20 → on-page boost; losers → check for cannibalisation or de-index. IndexNow-submit anything new (`indexnow`). Early months will show *zero clicks* — that is expected; judge on §5 leading indicators.
+
+### Monthly deep-dive (first working day, ~2 hrs)
+Full month-over-month across the whole KPI tree. Indexation health (valid ÷ submitted, bloat ratio), CWV pass rate (`crux`), DA/RD curve vs the `05` velocity target, content-cluster performance vs `02`, city×vendor heatmap vs `04`. Competitor check: shadiyana.pk RD count and any new venue pages (`ubersuggest`/`serper`). AI-citation probe: run 15–20 head queries through `serper`/`tavily`, log whether WW is cited. Output: a dated monthly memo with 3–5 prioritised actions feeding the next month's content/link calendar.
+
+### Quarterly strategy reset (~half day)
+Re-score the three scenarios in `01` against actuals — are we tracking conservative, base, or aggressive? Re-validate the keyword universe with fresh GSC + Ubersuggest enrichment (`02`), re-rank the programmatic backlog by *proven* impression demand (`04`), reset link targets (`05`), and reset the next quarter's KPI targets. This is where the 1M narrative is honestly recalibrated — if base is slipping, say so and adjust the page/link velocity, don't move the goalposts quietly.
+
+| Cadence | Cool-headed question | Primary sources |
+|---|---|---|
+| Weekly | What moved, what do I fix now? | GSC, GA4, Bing |
+| Monthly | Are leading indicators compounding? | + CrUX, Ubersuggest, serper |
+| Quarterly | Which scenario are we on; reset targets | All + `01`/`02`/`04`/`05` |
+
+---
+
+## 5. Leading vs lagging — judging the early months fairly
+
+The single most common way SEO programs get killed is judging month 2 by visitor count. At DA 1 with ~1 ranking keyword, **there is no traffic to measure** — and there won't be for months. Indexation precedes impressions; impressions precede clicks; clicks precede leads; links and DA gate how high any of it can climb. So early progress is *real* even when GA4 is flat.
+
+| Phase | Judge ON (leading) | Do NOT yet judge on (lagging) |
+|---|---|---|
+| M0–3 (foundation) | pages indexed, RDs won, CWV "Good", GSC impressions appearing, AI-crawler access | sessions, clicks, leads, rankings |
+| M4–9 (traction) | impression growth, first top-20 positions, CTR on indexed pages, RD velocity | total-traffic vanity number |
+| M10–18 (compounding) | clicks growth, top-10 keyword count, commercial-cohort rank | absolute 1M progress |
+| M19–24 (scale) | leads, commercial conv. rate, category share vs shadiyana | — (now judge on outcomes) |
+
+**The early-warning chain:** if impressions on new pages are flat, demand or indexation is broken — check coverage *before* writing more. If impressions rise but clicks don't, it's a title/CTR or SERP-feature problem, not a content problem. If clicks rise but leads don't, it's a CRO/UX problem on the vendor pages, not SEO. Each link in `impressions → clicks → leads` fails differently and is fixed by a different team — diagnosing *which* link broke is the entire point of the scoreboard. Tie every red metric back to the doc that owns the fix, and the measurement system becomes the steering wheel, not just the speedometer.

--- a/seo-strategy/mega-plan-2yr/10-resourcing-conversion-risk.md
+++ b/seo-strategy/mega-plan-2yr/10-resourcing-conversion-risk.md
@@ -1,0 +1,139 @@
+# 10 — Resourcing, Conversion & Risk
+
+> Purpose: close the three things a 24-month "1M/mo" plan cannot omit — **who/what it costs**, **how a visitor becomes a lead**, and **what happens if Google hits us**. This file fills the gaps the internal QA flagged (G1–G4). It is the most honest file in the set: it is where the ambition meets the bill.
+
+Honesty frame (same as every file here): **1M/mo organic is the Aggressive ceiling, not a promise.** The Base scenario in [01-traffic-model-to-1M.md](01-traffic-model-to-1M.md) (§2.3) is the plan-of-record. The real north star is **organic leads/bookings**, not visitors — see §2.
+
+---
+
+## 1. Resourcing & budget model
+
+The traffic model implies a content + link machine. That machine has two honest build paths. Pick one explicitly — the plan's velocity assumptions break if you fund neither.
+
+### 1.1 The two paths
+
+| | **Path A — Lean (operator + AI)** | **Path B — Small team** |
+|---|---|---|
+| Who | You + Claude/MCP stack, ~24/7 | You + 1 content writer (Urdu/English) + 1 part-time outreach/PR + freelance photographer |
+| Sustainable velocity | 3–6 quality pages/day (AI-drafted, you edit) | 10–15 pages/day + dedicated link outreach |
+| Realistic 24-mo ceiling | **Base scenario** (~500k/mo) is reachable; 1M is a stretch | **Aggressive scenario** (1M) becomes plausible |
+| Bottleneck | Your editing hours + link-building (can't be fully automated) | Cash + management overhead |
+
+**The honest implication:** **1M/mo realistically requires Path B at some point** (months ~7–12 onward). On Path A alone, plan for the Base case and treat 1M as aspirational. Do not assume solo + AI = 1M; AI accelerates drafting, but link-building, real photography, PR relationships, and editorial judgment are human-gated.
+
+### 1.2 Indicative monthly cost (PKR; ranges, not precision)
+
+| Line item | Lean (Path A) | Team (Path B) | Notes |
+|---|---|---|---|
+| Content writer(s) | — | 80k–200k | 1 strong bilingual writer; scale to 2 in Year 2 |
+| Outreach/PR (part-time) | — | 50k–120k | Link-building is the #1 lever — see [05](05-authority-linkbuilding.md) |
+| Photography (first-party) | 20k–60k | 60k–150k | Replaces Pexels placeholders; E-E-A-T + image SEO ([03](03-content-engine.md) §4) |
+| Paid SEO tools (when needed) | 0–15k | 25k–70k | Ahrefs/Semrush/DataForSEO — only when free tier caps bite ([07](07-mcp-operating-manual.md) §4) |
+| Hosting/infra delta | minimal | minimal | Already on Vercel/Neon; programmatic pages are cheap |
+| **Indicative total/mo** | **~20k–135k** | **~215k–540k** | USD ≈ $75–480 (lean) / $770–1,940 (team) at ~280 PKR/USD |
+
+These are **planning ranges to size the decision, not quotes.** Replace with real numbers once you choose a path. The point: a 1M plan with zero cost line is fiction — fund Path B before committing to the Aggressive curve.
+
+### 1.3 Phase → resourcing gate
+
+- **M1–M3 (Foundation + quick wins):** Path A is fine. Prove the engine (rankings appear, GSC impressions climb) before spending.
+- **M4–M6 (depth):** add the first writer if Base milestones are hit (see decision-gates in [08](08-24-month-roadmap.md) §9).
+- **M7–M12 (scale):** Path B required to keep the content velocity in [03](03-content-engine.md) §3 honest.
+- **M13–M24 (1M push):** full team or accept the Base ceiling.
+
+---
+
+## 2. Conversion surface & lead definition (the real north star)
+
+Every file says "judge on leads, not visitors." This section defines what a *lead* actually is, so [09-measurement-cadence.md](09-measurement-cadence.md) can measure it.
+
+### 2.1 The conversion events (define these in GA4 — Step Zero unblocks this)
+
+Primary (count as a "lead"):
+1. **Vendor contact reveal** — user clicks to reveal/visit a vendor's phone/WhatsApp on a vendor profile or `{vendor}×{city}` page.
+2. **Enquiry / "Get quotes" form submit** — the marketplace lead form.
+3. **WhatsApp click-through** — `wa.me` click (dominant PK contact channel; instrument it).
+
+Secondary (assisted/micro-conversions):
+4. Budget-calculator completion, checklist/timeline tool use (intent signal; feeds remarketing + internal links).
+5. Save/shortlist a vendor.
+
+**Action:** these must be GA4 conversion events with the source/medium attributed. Until they exist, the program is unmeasurable on its real goal — wire them in the same sprint as GSC/GA4 ([07](07-mcp-operating-manual.md) §2).
+
+### 2.2 Where the CTA lives
+
+- **Money pages** (`{vendor}×{city}`, vendor profiles): contact/WhatsApp/enquiry above the fold and repeated after the vendor list.
+- **Listicles** ("Best {vendor} in {city}"): each entry links to its vendor profile (the conversion surface), not a dead end.
+- **Informational galleries/guides** (mehndi, dress): these do **not** convert directly — their job is the **internal-link bridge** to money pages (see §2.3). A gallery with no contextual link to "book a mehndi artist in {city}" is wasted traffic.
+
+### 2.3 The informational→commercial bridge (load-bearing — measure it)
+
+The entire reason to chase low-converting informational volume (mehndi/dress) is to funnel it to commercial pages. If that bridge doesn't work, 1M is pure vanity. So it is a tracked KPI:
+
+- **Bridge CTR** = % of informational-page sessions that click through to a money/vendor page.
+- **Assisted conversions** = leads where an informational page was an earlier touch (GA4 path/attribution).
+- Target: establish a baseline in the first 90 days of real traffic, then improve quarter over quarter. Add this KPI to [09](09-measurement-cadence.md) §1.
+
+### 2.4 CRO principle
+
+If clicks rise but leads don't, it is a **conversion/UX problem on the money pages, not an SEO problem** — fix the CTA, trust signals (reviews, real photos, PKR pricing), and page speed before assuming you need more traffic.
+
+---
+
+## 3. Algorithm-risk & recovery playbook
+
+Publishing thousands of templated pages from a DA-1 domain carries real, specific risk. Name it and mitigate it.
+
+### 3.1 The risks
+
+1. **Programmatic / thin-content demotion or manual action** — the biggest risk at scale. Google's "scaled content abuse" policy targets mass low-value pages.
+2. **Core update volatility** — broad ranking swings independent of anything we did.
+3. **De-indexation of thin city×vendor combos** — index bloat dragging the whole domain.
+
+### 3.2 Mitigations (mostly already designed into the plan)
+
+- **Uniqueness floor per programmatic page** ([04](04-programmatic-architecture.md) §3) — real vendor data, unique intro copy, PKR pricing, local FAQ. No boilerplate-only pages.
+- **Thin-page noindex guard** ([04](04-programmatic-architecture.md) §4) — combos below the vendor threshold stay `noindex,follow` until populated. This is the single most important spam-safety control; protect it.
+- **Gradual rollout, not a 8,000-page dump** — publish in waves so quality is monitored ([08](08-24-month-roadmap.md)).
+- **E-E-A-T signals** ([03](03-content-engine.md) §4) — author bylines, first-party photography, factual accuracy.
+- **AI-content discipline** — AI-assisted drafting is fine; AI-only unedited mass pages are exactly what gets penalized. Human editing is the firewall.
+
+### 3.3 Recovery steps (if hit)
+
+1. Diagnose: GSC Manual Actions report + coverage/impressions drop pattern (sitewide vs section) via the own-data MCPs.
+2. If manual action (scaled content): `noindex` or improve the offending page set, raise the uniqueness floor, request reconsideration.
+3. If core update: do **not** panic-edit. Assess over 2–4 weeks, double down on E-E-A-T and the pages that held, document changes, wait for the next update.
+4. **Owner:** this file + [06-technical-geo.md](06-technical-geo.md) (technical regression) jointly own incident response. Log every incident and response in the monthly review ([09](09-measurement-cadence.md) §4).
+
+---
+
+## 4. Competitor roster (beyond shadiyana)
+
+The plan's primary benchmark is **shadiyana.pk** (DA ~22, ~66k/mo, ~850 referring domains, venue-dominated — canonical profile lives in [02-keyword-universe.md](02-keyword-universe.md)). But 1M-scale category leadership means beating the whole SERP. Named set (from prior research in `../SEO-MASTER-PLAN.md` §3):
+
+| Competitor | Threat type | Notes |
+|---|---|---|
+| **shadiyana.pk** | Direct marketplace (primary) | Venue-strong, non-venue + content + Urdu thin = our wedge |
+| **shehnai.pk** | Content threat | Best blog ("Wedding Cost in Pakistan", city venue guides) — beat on cost/budget content |
+| **urdupoint.com** | High-DA hall directory + Urdu | More a **backlink target** than a rival |
+| **wedmegood.com** (PK section) | High-DA, India-based | Shallow on PK — outdepth on local specificity |
+| eventza.pk, hamaravenue.com | Venue-only directories | Narrow; beatable on category breadth |
+| shadibox.com, shadibazar.pk, shadikart.com.pk | Commerce/resale | Different intent; watch, don't chase |
+| **Pinterest / Instagram** | Informational-SERP owners | They own mehndi/dress *image* intent — the real "competitor" for the informational mass ([01](01-traffic-model-to-1M.md) §4.2 risk) |
+
+Matrimonial "shaadi.com"-type sites = different intent, ignore. Re-run a live competitor scan quarterly via `serper` + `firecrawl` ([07](07-mcp-operating-manual.md) §3 quarterly).
+
+---
+
+## 5. Cross-references
+- Traffic model & scenarios → [01-traffic-model-to-1M.md](01-traffic-model-to-1M.md)
+- Canonical keyword/competitor numbers → [02-keyword-universe.md](02-keyword-universe.md)
+- Content velocity & E-E-A-T → [03-content-engine.md](03-content-engine.md)
+- Programmatic uniqueness & noindex guards → [04-programmatic-architecture.md](04-programmatic-architecture.md)
+- Link velocity & PR → [05-authority-linkbuilding.md](05-authority-linkbuilding.md)
+- Technical/GEO & incident response → [06-technical-geo.md](06-technical-geo.md)
+- MCP cadences & Step Zero → [07-mcp-operating-manual.md](07-mcp-operating-manual.md)
+- Month-by-month roadmap & gates → [08-24-month-roadmap.md](08-24-month-roadmap.md)
+- KPIs, dashboard, conversion metrics → [09-measurement-cadence.md](09-measurement-cadence.md)
+
+_Status: drafted 2026-06-15. Budget figures are planning ranges, not quotes. Lead/conversion targets to be set from the GA4 baseline once Step Zero is complete._

--- a/seo-strategy/mega-plan-2yr/11-whole-pakistan-coverage.md
+++ b/seo-strategy/mega-plan-2yr/11-whole-pakistan-coverage.md
@@ -1,0 +1,182 @@
+# 11 — Whole-Pakistan Coverage: The Exact Page-Count & City-Tier Model
+
+*Purpose: replace hand-waved "150–300 cities × vendors = 1M pages" guesses with a **real-geography, inventory-gated** page-count model for weddingwala.pk. This file sizes the **supply side** (how many pages can exist and should be indexed) against verified Pakistan geography; `01-traffic-model-to-1M.md` sizes the **demand side**; `04-programmatic-architecture.md` defines the **engine** that mints these URLs. Read all three together.*
+
+> **Honesty banner (non-negotiable).** Pakistan has ~127 cities over 100k people, but we do **not** target 127 — most have **no biddable wedding-vendor inventory** and would produce thin doorway pages (Google's "scaled content abuse"). The number that matters is not *cities* or *generated URLs* — it is **inventory-gated, genuinely-useful, indexed pages**. Every count below is split into **theoretical capacity** (the template grid) vs **indexable** (combos that pass the ≥1-vendor + uniqueness floor in `04-programmatic-architecture.md` §3–4). We never mass-publish empty city pages. Authority/links remain the #1 ranking lever (one honest sentence — see `05-authority-linkbuilding.md`); page supply is necessary, never sufficient.
+
+---
+
+## 1. Real Pakistan geography (verified, sourced)
+
+Pakistan's first digital census (the **2023 Census**, reference date 1 March 2023, Pakistan Bureau of Statistics) is the authoritative baseline. The headline numbers that bound any "whole Pakistan" claim:
+
+| Administrative unit | Count | Notes |
+|---|---|---|
+| Provinces + territories | **7** | Punjab, Sindh, KP, Balochistan, Gilgit-Baltistan (GB), Azad Jammu & Kashmir (AJK), Islamabad Capital Territory (ICT) |
+| Divisions | ~37 | Intermediate tier between province and district |
+| **Districts** | **~169–171** | Punjab 41, Sindh 30, KP ~40, Balochistan ~36, GB 14, AJK 10 (+ ICT) |
+| **Tehsils** | **~600+** (directional) | Punjab ~162, Sindh 138; KP/Balochistan add ~130/~90; no single clean national 2023 figure published |
+| **Cities/towns over 100k** | **127** | The realistic upper bound of "cities" worth discussing for any consumer marketplace |
+| Megacities (>10M) | 2 | Karachi, Lahore |
+
+### 1.1 The 127 cities-over-100k, by province (the only "cities" figure that matters)
+
+| Province / territory | Cities > 100k | Share |
+|---|---|---|
+| **Punjab** | **81** | 64% |
+| **Sindh** | **22** | 17% |
+| **Khyber Pakhtunkhwa** | **13** | 10% |
+| **Balochistan** | **8** | 6% |
+| **Azad Kashmir (AJK)** | **2** | 2% |
+| **Islamabad Capital Territory** | **1** | 1% |
+| Gilgit-Baltistan | 0 (none > 100k) | — |
+| **Total** | **127** | 100% |
+
+> **Strategic read:** Pakistan's urban wedding economy is overwhelmingly **Punjab-weighted (64% of all 100k+ cities)**, then a Sindh corridor (Karachi → Hyderabad → Sukkur/Larkana), with KP (Peshawar/Mardan/Mingora) and one node in Balochistan (Quetta). GB has zero cities over 100k — there is **no programmatic case** for GB beyond a single token hub. The friend's "150–300 cities" is geographically impossible at any meaningful population threshold: even counting *every* town over 100k you reach **127**, and most of those 127 have a wedding-services economy too informal to populate a marketplace.
+
+### 1.2 The demand-relevant city ladder (2023 populations)
+
+The top ~24 cities capture essentially all of the addressable urban wedding-services market:
+
+| Rank | City | 2023 pop | Province | In `CITIES` today? |
+|---|---|---|---|---|
+| 1 | Karachi | ~18.9M | Sindh | ✅ |
+| 2 | Lahore | ~13.0M | Punjab | ✅ |
+| 3 | Faisalabad | 3.69M | Punjab | ✅ |
+| 4 | Rawalpindi | 3.36M | Punjab | ✅ |
+| 5 | Gujranwala | 2.51M | Punjab | ✅ |
+| 6 | Multan | 2.22M | Punjab | ✅ |
+| 7 | Hyderabad | 1.92M | Sindh | ✅ |
+| 8 | Peshawar | 1.91M | KP | ✅ |
+| 9 | Quetta | 1.57M | Balochistan | ✅ |
+| 10 | Islamabad | 1.11M | ICT | ✅ |
+| 11 | Sargodha | 0.98M | Punjab | ⬜ |
+| 12 | Sialkot | 0.91M | Punjab | ✅ |
+| 13 | Bahawalpur | 0.90M | Punjab | ✅ |
+| 14 | Jhang | 0.61M | Punjab | ⬜ |
+| 15 | Sheikhupura | 0.59M | Punjab | ⬜ |
+| 16 | Gujrat | 0.57M | Punjab | ⬜ |
+| 17 | Sukkur | 0.56M | Sindh | ⬜ |
+| 18 | Larkana | 0.55M | Sindh | ⬜ |
+| 19 | Sahiwal | 0.54M | Punjab | ⬜ |
+| 20 | Okara | 0.53M | Punjab | ⬜ |
+| 21 | Rahim Yar Khan | 0.52M | Punjab | ⬜ |
+| 22 | Kasur | 0.51M | Punjab | ⬜ |
+| 23 | Dera Ghazi Khan | 0.49M | Punjab | ⬜ |
+| 24 | Wah Cantt | 0.40M | Punjab | ⬜ |
+
+**Sources:** [2023 Pakistani census](https://en.wikipedia.org/wiki/2023_Pakistani_census) · [List of cities in Pakistan by population](https://en.wikipedia.org/wiki/List_of_cities_in_Pakistan_by_population) · [Districts of Pakistan](https://en.wikipedia.org/wiki/Districts_of_Pakistan) · [List of districts in Punjab](https://en.wikipedia.org/wiki/List_of_districts_in_Punjab,_Pakistan) · [List of tehsils of Punjab](https://en.wikipedia.org/wiki/List_of_tehsils_of_Punjab,_Pakistan) · [List of districts in Sindh](https://en.wikipedia.org/wiki/List_of_districts_in_Sindh) · [List of tehsils of Sindh](https://en.wikipedia.org/wiki/List_of_tehsils_of_Sindh) · [List of districts in KP](https://en.wikipedia.org/wiki/List_of_districts_in_Khyber_Pakhtunkhwa) · [List of districts in Balochistan](https://en.wikipedia.org/wiki/List_of_districts_in_Balochistan) · [PBS](https://www.pbs.gov.pk/).
+
+---
+
+## 2. The tiered city model (exact counts — demand × inventory, not all 127)
+
+We target **~32 cities at full build-out**, not 127. The cut line is **demand AND realistic vendor inventory**, not population alone (a 250k city with zero biddable photographers earns one `noindex` shell, not a published page).
+
+| Tier | Definition | Cities | Count | Cumulative |
+|---|---|---|---|---|
+| **Tier 1 — Metros** | >2.5M, dense vendor supply, where bookings concentrate | Karachi, Lahore, Islamabad, Rawalpindi, Faisalabad, Gujranwala | **6** | 6 |
+| **Tier 2 — Major secondary** | 0.5M–2.5M, real but thinner supply (today's `CITIES` rounded out) | Multan, Hyderabad, Peshawar, Sialkot, Bahawalpur, Quetta | **6** | 12 |
+| **Tier 3 — Demand-credible** | 0.4M–1M, add **only as vendors onboard** | Sargodha, Gujrat, Sheikhupura, Sukkur, Larkana, Sahiwal, Okara, Rahim Yar Khan, Kasur, Jhang, Dera Ghazi Khan, Wah Cantt, Mardan, Nawabshah, Mingora, Jhelum, Mirpur (AJK), Abbottabad, Rawalpindi-region towns | **~20** | **~32** |
+| **Long-tail — Watchlist** | Remaining ~95 of the 127, plus tehsil-level | Sadiqabad, Khanewal, Hafizabad, Chiniot, Kamoke, Burewala, Mirpur Khas, Turbat, Kohat, … | ~95 (mostly never published) | (watchlist) |
+
+> **The hard line:** Tiers 1–2 (**12 cities**) are our current live set and the proven-demand core. Tier 3 (**~20 cities**) is the realistic *expansion frontier* over 24 months, gated city-by-city on inventory. The **~95 long-tail cities are NOT a build target** — they exist as `noindex,follow` shells that auto-flip to indexable *if and when* a real vendor ever onboards there. This is the structural difference from the friend's plan: he counts all cities as pages-to-publish; we count cities as **capacity that only converts to a page when inventory exists.**
+
+---
+
+## 3. Exact page-count math by page TYPE
+
+Two numbers per row: **Theoretical (T)** = the full template cross-product (capacity ceiling), and **Indexable (I)** = what actually passes the ≥1-vendor + uniqueness gate and gets sitemapped. **I ≪ T by design.** All event/listicle/strong-city gates per `04-programmatic-architecture.md` §4.
+
+### 3.1 Static / hub surfaces (always indexable — editorial, not gated)
+
+| Page type | URL pattern | Count | Notes |
+|---|---|---|---|
+| Vendor-type hubs | `/{vendor-type}` | 11 → ~17 (with expansion) | One per live type |
+| City hubs | `/cities/{city}` | 12 → ~32 | One per live city |
+| Province hubs | `/{province}` (new) | 7 | Punjab, Sindh, KP, Balochistan, GB, AJK, ICT |
+| Compare / glossary / blog index / real-weddings | misc | ~15 | Existing |
+| **Hub subtotal** | | **~45 → ~70** | High-equity internal-link spine |
+
+### 3.2 The programmatic grid (the volume — inventory-gated)
+
+| Page type | Pattern | Theoretical (capacity) | Indexable @ M24 (realistic) | Gate |
+|---|---|---|---|---|
+| **{service}×{city} category** | `/{type}/{city}` | 17 types × 32 cities = **544** | **~300–360** | ≥1 vendor; ≥3 → "strong" |
+| **"Best {service} in {city}" listicle** | `/best/{type}-in-{city}` | same 544 | **~120–180** | `MIN_VENDORS_FOR_LISTICLE = 3` |
+| **{service}×{city}×{event}** | `/{type}/{city}/{event}` | ~8 event-eligible types × 12–20 cities × 6 events ≈ **600–960** | **~250–500** | event-eligible type only + ≥3 vendors + unique copy |
+| **Vendor PROFILE leaves** ⭐ | `/{type}/{city}/{name}-{id}` | = # onboarded businesses (unbounded) | **~3,000–6,000+** | has ≥1 photo + description |
+| **Programmatic subtotal** | | T ≈ 1,700 + N leaves | **I ≈ 3,700–7,000** | |
+
+> ⭐ **The vendor-profile leaf is the real indexed-volume driver** — not the {service}×{city} grid. The grid tops out at a few hundred genuinely-strong combos; **leaves scale with onboarding velocity and have no thin-content risk** (each carries unique first-party data: real photos, PKR packages, verified reviews, service area). This is exactly how shadiyana.pk bootstrapped DA 22 — ranking #1 for individual venue *names* (`04-programmatic-architecture.md` §2). **Onboarding velocity = indexable-page velocity.** Our ~17-category namespace (vs a venue-only competitor) makes the brandable-query surface several times larger.
+
+### 3.3 Informational / blog (volume + authority, lightly gated by quality only)
+
+| Page type | Examples | Count @ M24 (Base → Aggressive) |
+|---|---|---|
+| Content pillars / cost guides | "Wedding Cost in Pakistan 2026", "{vendor} cost in {city}" | ~40 → ~80 |
+| Informational galleries | mehndi designs, bridal looks, decor ideas (the ~673k–1.1M/mo demand) | ~150 → ~300 |
+| Real-weddings recaps | per-wedding, vendor-credited (link manufacturing) | ~60 → ~200 |
+| **Informational subtotal** | | **~250 → ~580** |
+
+### 3.4 Total indexable ladder (the number that matters)
+
+| Bucket | M6 | M12 | M24 (Base) | M24 (Aggressive) |
+|---|---|---|---|---|
+| Hubs (static) | ~45 | ~55 | ~65 | ~70 |
+| {service}×{city} category | ~110 | ~200 | ~300 | ~360 |
+| "Best of" listicles | ~30 | ~80 | ~130 | ~180 |
+| {service}×{city}×{event} | 0 (flag-off) | ~80 | ~250 | ~500 |
+| Vendor profile leaves ⭐ | ~550 | ~1,500 | **~3,000** | **~6,000** |
+| Informational / blog | ~120 | ~250 | ~400 | ~580 |
+| **Total INDEXABLE** | **~855** | **~2,165** | **~4,145** | **~7,690** |
+| *Theoretical URLs generated* | *~2k* | *~5k* | *~9k* | *~15k* |
+
+> The **theoretical-vs-indexable gap is the whole strategy**: at M24 Aggressive we *generate* ~15k URLs but *index* ~7.7k — the other ~7k are `noindex,follow` thin/empty combos that protect crawl budget and keep the indexed set quality-dense. The friend's model has no such gap; he would publish all ~15k, ~half of them thin → demotion risk for the whole domain.
+
+---
+
+## 4. Reconciliation to the traffic model (and why we beat the friend's approach)
+
+The indexable ladder in §3.4 lands **exactly on the demand-side targets** in `01-traffic-model-to-1M.md` §2 — by construction, not coincidence:
+
+| Scenario | `01` target (quality-indexed pages @ M24) | This file's §3.4 supply | Maps toward |
+|---|---|---|---|
+| Conservative | ~1,500 | (sub-Base ramp; leaves slow) | ~160k/mo |
+| **Base (plan of record)** | **~4,000** | **~4,145** ✅ | **~500k/mo** |
+| Aggressive (ceiling) | ~8,000 | ~7,690 ✅ | ~1,000,000/mo |
+
+> **How ~4k–8k pages map toward ~1M/mo (honest caveat):** per `01` §2.4, the arithmetic is *pages × blended avg visits/page*. ~8k indexable pages × ~125 blended visits/mo ≈ 1.0M **only if** a few hundred informational galleries average 1k–5k each AND we reach ~22% category capture AND DA ~35+/~600 referring domains. **All three must hold simultaneously** — that is what makes 1M a *ceiling we architect toward, not a promise*. Plan and budget against **Base (~4,145 pages → ~500k/mo, ~200k of it commercial)**; build the engine capable of Aggressive so the upside is captured if links + velocity + image-SERP capture all break our way. North star stays **leads, not visits** (`01` §4.3).
+
+### 4.1 Explicit contrast with the friend's "mass-publish" model
+
+| Dimension | Friend's playbook | Wedding Wala (this plan) |
+|---|---|---|
+| City target | "150–300 cities" | **127 exist >100k; we publish ~12 now → ~32 max, inventory-gated** |
+| Page premise | "2,273 pages" / publish all cities × vendors | **Theoretical ~9k–15k; INDEXABLE ~4k–8k (gated)** |
+| Empty combos | Published (e.g. `/wedding-djs/quetta` with 0 DJs) | **`noindex,follow`, auto-flip when first vendor onboards** |
+| Primary volume driver | {vendor}×{city} grid | **Vendor PROFILE leaves (unique first-party data, no thin risk)** |
+| Thin-content exposure | **High** — half the grid is shells → "scaled content abuse" / sitewide demotion | **Low** — uniqueness floor + ≥1-vendor gate per `04` §3–4 |
+| Ranking claim | "12 months = #1" | **Compete for #1; never guaranteed; leads = north star** |
+
+> **The thin-content penalty risk, stated plainly:** Google's March-2024 "scaled content abuse" policy demotes domains that publish large volumes of low-value, templated pages. Mass-publishing all 127 cities × 17 vendor types = **2,159 URLs**, of which the overwhelming majority would have **zero real vendors** — i.e. thin doorways. That is not "1M coverage"; it is a sitewide-demotion trap from DA 1. **Inventory-gating + vendor-profile-led growth is the only correct path**: the indexed set grows *with proven supply*, every page differs by *data not just city name*, and crawl budget is spent on pages that can actually rank and convert.
+
+---
+
+## 5. What to build first (sequence tied to 11 vendor types + 12 cities, expanding outward)
+
+Strictly additive, flag-gated, zero-downtime (mirrors `04` §8 and `TODO.md` §D). **Depth before breadth.**
+
+| Wave | Window | Build | Indexable add |
+|---|---|---|---|
+| **W1 — Deepen the live core** | M0–M3 | Make all 11 types × 12 cities = **132** combos *strong*: unique per-city editorial, PKR ranges, ≥3 vendor cards, FAQ, internal mesh. Onboard hard in Tier-1 (KHI/LHR/ISB/RWP) to push leaves past the ≥3 gate. | +category strong, +leaves |
+| **W2 — Profile flywheel + listicles** | M3–M6 | Wire **IndexNow** into onboarding; flip `LISTICLE_PAGES_ENABLED` for combos clearing `MIN_VENDORS_FOR_LISTICLE=3`; ship first "Best {service} in {city} 2026" set + flagship cost pillars. | +leaves (mass), +listicles |
+| **W3 — Category expansion** | M6–M12 | Add **groom-wear/sherwani + bridal-jewellery** to `VENDOR_TYPES`+ENUM; activate dormant BK-100.55 slugs (qawwali, dhol, choreographers, cakes, florists…). Grid widens 11→~17 types. | +category, +leaves |
+| **W4 — City expansion (Tier 3)** | M9–M18 | Add `CITIES` + `city-editorial.ts` for Sargodha, Gujrat, Sukkur, Larkana, Sheikhupura, Sahiwal, Okara, RYK, Kasur, Mardan, Mingora, Jhelum, Mirpur — **one city flips live only when its first vendors onboard**. ~12→~32 cities. | +category, +leaves |
+| **W5 — Event layer + province hubs** | M12–M24 | `EVENT_PAGES_ENABLED` for event-eligible types (mehndi/decor/makeup/photography/catering/venue × mehndi/barat/walima/mayun/dholki/nikkah); ship 7 province hubs; scale informational galleries → funnel to money pages. | +event, +informational |
+
+> **Sequencing rule:** never open a new city or category until the current one has real inventory and strong (≥3-vendor) pages — otherwise the expansion mints `noindex` shells and dilutes nothing useful. Geography is *capacity*; **onboarding is the throttle.** Punjab-first (64% of cities + densest supply), then the Sindh corridor, then KP/Balochistan single nodes; GB stays a token hub only.
+
+---
+
+_Created 2026-06-15. Cross-refs: `01-traffic-model-to-1M.md` (demand sizing), `04-programmatic-architecture.md` (the engine + gates), `TODO.md` §D (execution). Geography per the 2023 Pakistani census (PBS). All page counts are capacity-vs-indexable; we never mass-publish empty city pages._

--- a/seo-strategy/mega-plan-2yr/12-page-blueprint.md
+++ b/seo-strategy/mega-plan-2yr/12-page-blueprint.md
@@ -1,0 +1,174 @@
+# 12 — The Definitive {service}×{city} Page Blueprint (the "1000× better" money-page & listicle spec)
+
+> **Purpose:** the canonical, copy-this-every-time spec for the commercial money page (`/{vendor-type}/{city}`) and its `/best/{vendor-type}-in-{city}` listicle sibling. Every programmatic money page and every "Best of" listicle MUST conform to the block order, keyword-placement map, and schema graph below. This file supersedes ad-hoc page structures and is the *page-level* companion to the *system-level* siblings.
+>
+> **Read alongside:** [`04-programmatic-architecture.md`](04-programmatic-architecture.md) (where these pages sit in the URL matrix + thin-page guards + internal-link mesh), [`02-keyword-universe.md`](02-keyword-universe.md) §5A/§5C (the demand + the money-vs-cost split that prevents cannibalization), [`06-technical-geo.md`](06-technical-geo.md) §3/§5 (schema builders in `lib/seo/jsonld.ts` + GEO), [`03-content-engine.md`](03-content-engine.md) §2B/§2D (content tiers), and the worked example [`briefs/wedding-photographers-lahore-brief.md`](briefs/wedding-photographers-lahore-brief.md). Conventions resolve to [`00-README.md`](00-README.md).
+>
+> **Honesty (non-negotiable, per [00-README.md](00-README.md) rules 1–5):** this blueprint engineers a page to *compete for #1* — it does **not** guarantee #1. Ranking also needs authority/links (the single biggest off-page lever — see [05](05-authority-linkbuilding.md)), a verified **Google Business Profile** (positions 1–3 on `{vendor} {city}` are the local pack), and time. All PKR figures are **indicative/directional** market bands, not Wedding Wala quotes; all ratings/review counts in schema are **real** backend data only — never synthesized (fabricated `reviewCount` is a manual-action risk). Pages stay **inventory-gated**: combos below the vendor threshold render `noindex,follow` and are excluded from the sitemap — we never mass-publish empty city pages (that is scaled-content-abuse / thin-content penalty territory).
+
+---
+
+## 1. Critique of the friend's 11-H2 structure (keep / fix / missing) → our superior order
+
+His doc proposes: H1 "Best [Vendor] in [City] Pakistan"; H2s = Top services · Why hire · What to look for · Average price · How to book · Popular wedding areas · Packages · Reviews & ratings · FAQ · Related vendors.
+
+| His block | Verdict | Why / what we do instead |
+|---|---|---|
+| H1 "Best [Vendor] in [City] **Pakistan**" | **Fix** | Trailing "Pakistan" is keyword-stuffy and rarely matches real PK queries (`wedding photographers in lahore`, not `…lahore pakistan`). Our H1 = the exact primary phrase, natural. Reserve "best" for the **listicle** sibling (`/best/…`), not the grid money page — that is the cannibalization split (§6). |
+| Top services | **Keep, merge** | Useful, but as a thin standalone H2 it's filler. We fold it into the **answer-first lead** + the vendor cards (each card lists specialties). |
+| Why hire | **Cut as H2** | Generic "why hire a photographer" is zero-intent fluff that bloats word count without earning a keyword. We replace it with **unique city editorial** (real neighborhoods, season, venue character) — the actual uniqueness signal that beats a token-swap competitor. |
+| What to look for | **Keep, upgrade** | Good instinct. We make it a concrete **"X things to check before you book"** checklist (scannable, snippet-shaped) — not prose. |
+| Average price | **Keep, transform** | A single "average price" is misleading and un-citable. We ship an **indicative PKR price-TIER table** (Budget / Mid / Premium / Luxury, with what each includes) — already built into our template. Tables are over-represented in AI citations. |
+| How to book | **Keep, shrink** | One short block; we make it the path to the **lead-capture CTA**, not a tutorial. |
+| Popular wedding areas | **Keep** | Genuinely local + good for GBP/near-me relevance. We weave areas into the **city editorial** and image alts (DHA, Gulberg, Johar Town for Lahore). |
+| Packages | **Merge into price-tier table** | Redundant with "average price" as two blocks. One tier table does both. |
+| Reviews & ratings | **Keep, make real** | Critical — but only with **real reviews + AggregateRating schema** from verified bookings. His generic doc risks fake reviews (penalty). Ours are backend-sourced or omitted. |
+| FAQ | **Keep, expand + schema** | Keep, but tie every Q to real PAA/long-tail and mark up with **FAQPage schema** (our single biggest GEO lever). |
+| Related vendors | **Keep, formalize** | Good for internal equity. We turn it into the **internal-link bridge mesh** (sibling types in-city, same type nearby cities, up to hubs, *and* the cost/how-to guide). |
+
+**What his structure is entirely MISSING (our net-new blocks):**
+1. **Answer-first lead (40–60 words)** for AI Overviews / ChatGPT / Perplexity / Copilot citation + featured snippets — the first self-contained passage with the PKR figure. (His hero is 150–200 generic words; ours leads with the *answer*.)
+2. **Real vendor list with per-vendor ratings, PKR price band, specialties, areas served** (ItemList schema) — beats the top PK competitor (`shadiyana.pk` directory list with *no pricing*, thin copy).
+3. **"Questions to ask before booking"** (maps to PAA) — distinct from the "things to check" checklist.
+4. **Event-by-event notes** (mehndi / barat / walima / mayun / nikkah) — the multi-function Pakistani-wedding reality his generic (part-Indian, part-AI) doc ignores.
+5. **Internal-link bridge to the cost/how-to pillar** — the intent split that captures transactional research without cannibalizing the money page (§6).
+6. **E-E-A-T trust strip** (verified-vendor badges, real bookings/enquiry count, last-updated date, author/editor byline) — invisible in his doc.
+7. **Honest indicative-pricing callout** — labels PKR as directional market bands, not quotes (his "average price" implies false precision).
+
+He also ships flaws we explicitly avoid: a **"12 months = #1" guarantee** (we never promise rank), **Indian competitors** (Shaadidukaan/Shaadiabaat) and **leftover Chinese text** from a generic AI doc, and a **"mass-publish 150–300 cities"** premise that is exactly the thin-content/scaled-abuse trap our inventory-gating prevents.
+
+---
+
+## 2. THE BLUEPRINT — exact content blocks, in order (money page `/{vendor-type}/{city}`)
+
+Block order top-to-bottom. "1000× better" column states the specific edge over the friend's doc and the live PK SERP.
+
+| # | Block | Purpose | What makes ours 1000× better |
+|---|---|---|---|
+| **B0** | **E-E-A-T trust strip** (above/at fold): "Updated June 2026 · Verified Wedding Wala vendors · N enquiries this month" + breadcrumb | Trust + freshness signal to users, Google, and AI extractors | Competitors show none. Real verified-badge + honest bookings/enquiry count + honest `dateModified` = experience/trust leg of E-E-A-T that AI-spun competitors can't fake. |
+| **B1** | **H1** = exact primary keyword (`Wedding Photographers in Lahore`) | One clean topical anchor | Natural phrasing that matches real PK queries; "best/Pakistan" stuffing removed (his H1 fix). One H1, primary only. |
+| **B2** | **Answer-first lead (40–60 words)** — restate query + direct answer + PKR figure + the 2–3 price drivers | Win AI Overviews / ChatGPT / Perplexity / Copilot citation **and** featured snippet | The decisive GEO upgrade. "Wedding photographers in Lahore typically charge **PKR 80,000–350,000**, depending on coverage (barat-only vs full mehndi–barat–walima) and whether cinematography is included…" Self-contained first passage = the quotable block. His 150-word hero is not extractable. |
+| **B3** | **Unique city editorial (120–180 words)** — neighborhoods (DHA, Gulberg, Johar Town), local venues, peak season (Decemberistan Nov–Feb), guest-count norms, load-shedding/generator note where relevant | Per-page uniqueness floor (kills thin-programmatic penalty) + local relevance + GBP/near-me signal | Generated from `lib/seo/city-editorial.ts` — **no two cities share boilerplate** ([04](04-programmatic-architecture.md) §3). Replaces his zero-intent "why hire" fluff with the actual ranking moat. |
+| **B4** | **Vendor list — real cards (≥6)**: name (→ leaf), rating + review count, PKR price band, specialties (traditional/candid/cinematic), areas served, "Get quote" CTA | The commercial core + the ItemList that wins ranked rich results / AI list answers | Top PK competitor's list has **no pricing**; ours has PKR band + rating + specialties per card → ItemList schema → "best X in city" list answers. Each card links to the vendor leaf (the navigational flywheel, [04](04-programmatic-architecture.md) §2). |
+| **B5** | **Indicative PKR price-TIER table** — Budget / Mid / Premium / Luxury × what each includes (days, edited photos, cinematic film, album, drone) | Transactional intent + AI/snippet table citation | Already in our template (`formatPriceRange()`). A *tiered* table (not his single "average") with inclusions = citable + honest. **Honesty callout:** "Indicative market bands, not Wedding Wala quotes." |
+| **B6** | **"X things to check before you book"** checklist (5–7 items) | Buyer-confidence + scannable snippet bait | Concrete checklist (portfolio consistency, style match, written contract, backup gear, team size, advance %, delivery timeline) vs his vague "what to look for" prose. |
+| **B7** | **Questions to ask before booking** (bulleted) | Captures People-Also-Ask; pre-qualifies the lead | Distinct from B6; mirrors real PAA phrasing → improves PAA + voice/AI capture. |
+| **B8** | **Photography/service by event** (mehndi · barat · walima · mayun · nikkah) — what changes per function | The multi-function Pakistani-wedding reality | Net-new vs his generic doc; also the long-tail bridge to `/{type}/{city}/{event}` event pages ([04](04-programmatic-architecture.md) §1). 100% PK-specific (no Indian/Chinese leftovers). |
+| **B9** | **How to book on Wedding Wala** (3 steps) → primary CTA | Converts to lead/booking | Short path to lead capture, not a tutorial. |
+| **B10** | **Real reviews block** + visible aggregate rating | Social proof + AggregateRating eligibility | Real verified-booking reviews only → schema below. Never synthesized. |
+| **B11** | **FAQ (8–10 Q&As)** — real PAA/long-tail (how much, advance booking, photo vs cinematography, drone allowed, how many photos, peak season) | GEO + rich result + long-tail capture | Visible FAQ + **FAQPage schema** = cheapest, highest-yield GEO lever ([06](06-technical-geo.md) §5.2). |
+| **B12** | **Internal-link bridges** — (a) → cost/how-to pillar (`/wedding-photography-cost-in-lahore`); (b) sibling types in-city (`/wedding-venues/lahore`, `/bridal-makeup-artists/lahore`); (c) same type, nearby cities; (d) up to type-hub + city-hub; (e) from feeding galleries | Equity flow + intent routing + the informational→commercial conversion bridge | Formalized mesh ([04](04-programmatic-architecture.md) §5), contextual in-body (weighs more than footer). The pillar link is the cannibalization-safe handoff (§6). |
+| **B13** | **Strong CTA / lead-capture** (sticky on mobile): "Get free quotes from Lahore wedding photographers" → enquiry form / WhatsApp | The north-star action (leads, not vanity rank) | Fires the GA4 conversion events (contact reveal / enquiry / WhatsApp — [10](10-resourcing-conversion-risk.md) §2.1). North star = leads ([00-README.md](00-README.md) rule 5). |
+
+**Listicle sibling (`/best/{vendor-type}-in-{city}`)** uses the same blocks but: H1 = "Best Wedding Photographers in Lahore (2026)"; B4 becomes a **ranked** list with a stated human selection methodology + per-vendor blurb; year in slug/title; gated by `MIN_VENDORS_FOR_LISTICLE` (≥3) and the `LISTICLE_PAGES_ENABLED` flag; ItemList becomes **ranked** ([06](06-technical-geo.md) §3, [03](03-content-engine.md) §2B). It targets `best wedding photographers in lahore` so it does not compete with the grid page's `wedding photographers in lahore`.
+
+---
+
+## 3. KEYWORD-PLACEMENT MAP (the operator's explicit ask)
+
+**Worked example: `wedding photographers in lahore`** (primary). Secondaries/long-tails from [`briefs/…`](briefs/wedding-photographers-lahore-brief.md) §1 + [02](02-keyword-universe.md) §5A. Each keyword maps to its **exact on-page location** — one secondary per H2, no stuffing.
+
+| On-page location | Exact element / value | Keyword placed | Role |
+|---|---|---|---|
+| **URL slug** | `/wedding-photographers/lahore` (locked, no trailing slash, lowercase, hyphen) | `wedding photographers` + `lahore` | Primary (split across path) |
+| **`<title>`** | `Wedding Photographers in Lahore — Prices, Packages & Top Studios (2026) \| Wedding Wala` | Primary verbatim + "prices/packages" secondary cues | Primary + 2 secondaries |
+| **Meta description** | "Compare verified wedding photographers in Lahore. Indicative PKR packages & prices, ratings, specialties, FAQs & how to choose (2026)." (~150 chars) | Primary + `packages` + `price` + `how to choose` | Primary + secondaries (CTR) |
+| **H1** | `Wedding Photographers in Lahore` | Primary, verbatim, exact-match | Primary |
+| **First 100 words (B2 answer-first lead)** | "**Wedding photographers in Lahore** typically charge PKR 80k–350k…" | Primary in first sentence + a price long-tail | Primary + snippet/GEO |
+| **H2 (B3 city editorial)** | "Wedding photography in Lahore: areas, venues & season" | `wedding photography` + `lahore` areas | Secondary (local) |
+| **H2 (B4 vendor list)** | "Top wedding photographers & studios in Lahore" | `best wedding photographer in lahore` / `wedding photographers in lahore` | Secondary |
+| **H2 (B5 price tier table)** | "Wedding photography packages & prices in Lahore" | `wedding photography packages lahore` + `wedding photography price in lahore` | 2 transactional secondaries |
+| **H2 (B6 checklist)** | "How to choose a wedding photographer in Lahore: 6 things to check" | `how to choose a wedding photographer in lahore` | Secondary (info-cue) |
+| **H2 (B8 by event)** | "Mehndi, barat & walima photography in Lahore" | `barat photographer lahore`, `pre wedding shoot photographer lahore` | Long-tail (event) |
+| **H2 (B11 FAQ)** | "Wedding photographer in Lahore — FAQs" | `wedding photographer lahore cost` (Q1) | Long-tail in Q text |
+| **Image alt** | `wedding photographer in Lahore — {event} {detail}` e.g. "wedding photographer in Lahore — barat candid shot, Gulberg" | Primary + event/area long-tail | Image SEO / Google Images |
+| **FAQ questions (B11)** | "How much does a wedding photographer cost in Lahore?" · "How far in advance should I book in Lahore?" · "Photography vs cinematography — what's the difference?" · "Is drone photography allowed?" · "How many edited photos do I get?" | PAA / long-tail one per Q | Long-tail + GEO |
+| **Internal anchor text (B12)** | → pillar: "wedding photography cost in Lahore"; → sibling: "wedding venues in Lahore", "bridal makeup artists in Lahore" | Pillar primary + sibling primaries | Equity + intent routing |
+| **Breadcrumb** | Home › Wedding Photographers › Lahore | Primary (split) | Crawl path + SERP |
+
+**Placement discipline:** primary appears in URL, `<title>`, H1, first 100 words, meta, **and exactly one H2** — then stop (over-repetition is stuffing). Secondaries are **one per H2**. Long-tails live in FAQ question text, image alts, and event H2s. Spelling variants (baraat/barat, walima/valima, nikah/nikkah) appear as **body/H-tag synonyms only — never as separate URLs** ([04](04-programmatic-architecture.md) §6).
+
+### Reusable `{service}/{city}` pattern (swap the two tokens)
+
+| Slot | Pattern |
+|---|---|
+| URL slug | `/{vendor-type}/{city}` |
+| `<title>` | `{Plural Service} in {City} — Prices, Packages & Top {Providers} ({year}) \| Wedding Wala` |
+| Meta description | `Compare verified {service} in {City}. Indicative PKR {packages/rates}, ratings, FAQs & how to choose ({year}).` |
+| H1 | `{Plural Service} in {City}` |
+| First 100 words | `{Plural service} in {City} typically cost PKR {low}–{high}, depending on {2 drivers}.` |
+| H2-1 (editorial) | `{Service} in {City}: areas, venues & season` |
+| H2-2 (list) | `Top {service} & {providers} in {City}` |
+| H2-3 (price) | `{Service} packages & prices in {City}` → carries `{service} packages {city}` + `{service} price in {city}` |
+| H2-4 (checklist) | `How to choose a {service-singular} in {City}: {N} things to check` |
+| H2-5 (by event) | `{Service} for mehndi, barat & walima in {City}` (only where event-eligible — [04](04-programmatic-architecture.md) §1) |
+| H2-6 (FAQ) | `{Service-singular} in {City} — FAQs` |
+| Image alt | `{service-singular} in {City} — {event} {detail}` |
+| Bridge anchors | → `/{service-cost-slug}` pillar; → `/{sibling-type}/{city}`; → `/{vendor-type}/{nearby-city}` |
+
+(Volumes/SD are **directional** Ubersuggest free-tier, a floor — re-validate against GSC once data accrues. [02](02-keyword-universe.md) is the canonical owner of all keyword numbers; this file quotes, never redefines.)
+
+---
+
+## 4. The full SCHEMA graph (and why each)
+
+Emitted via the existing typed builders in `lib/seo/jsonld.ts` and nested with `combineGraph()` — **additive, validated in CI via the `schema-org` MCP before flip** ([06](06-technical-geo.md) §3). Money page and listicle differ only in CollectionPage vs ranked ItemList.
+
+| Schema type | Where | Builder | Why |
+|---|---|---|---|
+| **CollectionPage / ItemList** | Page-level wrapper around the vendor list (B4) | `collectionPageLD` (listicle → ranked `ItemList`) | Tells Google the page is a curated set of vendors; ranked ItemList wins "best X in {city}" rich results + AI list answers — the highest-ROI *new* schema work. |
+| **Service** | The vendor-type service in the city | `serviceLD` | Disambiguates the offering ("Wedding Photography" service area = Lahore) for entity understanding + service rich results. |
+| **LocalBusiness** | Per vendor card (B4) + each leaf | `vendorLD` / `venueLD` | Each vendor is a real local business (name, area, geo) → local relevance + leaf flywheel ([04](04-programmatic-architecture.md) §2). |
+| **AggregateRating** | Per vendor (and page-level where genuine) | nested in `vendorLD` | Star ratings in SERP/AI. **Real review counts only** — fabricated `reviewCount` is a manual-action risk ([06](06-technical-geo.md) §3). |
+| **Review** | Real verified-booking reviews (B10) | `reviewLD` | Individual review markup → review snippets + E-E-A-T corroboration. Omit if none — never synthesize. |
+| **FAQPage** | The visible FAQ (B11) only | `faqLD` | Rich result + the single biggest GEO lever; FAQ schema only where visible FAQ content exists (Google policy). |
+| **BreadcrumbList** | Sitewide (B0) | `breadcrumbLD` | Crawl path + breadcrumb SERP enhancement; emitted everywhere already. |
+| **Organization + WebSite** | Sitewide | `organizationLD` + `webSiteLD` | Brand entity + sitelinks search box; corroborates "Wedding Wala" for AI brand association. |
+
+Listicle adds the **ranked** ItemList (position-indexed); cost/how-to **pillar** sibling uses `articleLD` + `faqLD` (+ `howToLD` where stepwise) — a different schema profile that reinforces the intent split (§6).
+
+---
+
+## 5. GEO / AI-search optimization & E-E-A-T signals
+
+**GEO (get cited by AI Overviews / ChatGPT / Perplexity / Copilot) — maps to [06](06-technical-geo.md) §5:**
+- **Answer-first (B2):** the 40–60-word lead = the self-contained passage AI extractors quote; restated question + answer + a PKR number.
+- **Tables (B5) + comparison blocks:** structured, scannable price-tier and vendor tables are over-represented in AI citations.
+- **FAQ → AI answers (B11):** visible FAQ + FAQPage schema feeds AI Q&A and PAA; questions mirror real long-tail.
+- **Freshness:** honest `dateModified` (Article/schema) + sitemap `lastModified`; "(2026)" framing refreshed annually — stale prices get dropped from AI answers.
+- **Access + discoverability:** `robots.ts` already allowlists GPTBot/OAI-SearchBot/PerplexityBot/ClaudeBot/Google-Extended/Bingbot-Copilot etc.; the page is listed in root `/llms.txt`; **Bing indexation = Copilot citation eligibility** (push via IndexNow on publish).
+- **Corroboration:** off-site brand mentions raise citation likelihood ([05](05-authority-linkbuilding.md)) — coordinate, but that section is out of scope here.
+
+**E-E-A-T signals on the page (B0 + B10 + bylines):**
+- **Verified-vendor badges** + honest **N enquiries/bookings this month** (real backend count — the *experience* leg).
+- **Real reviews + AggregateRating** from verified bookings only.
+- **Author/editor byline** with a real bio + `/about/{author}` profile (the `BlogAuthor.url` field already feeds `author` JSON-LD); legal/finance-adjacent copy gets a credited "reviewed by".
+- **Honest, dated, directional pricing** callout (no false precision; no rank guarantees).
+- **Real PK photography** (not generic stock) sourced via vendor partnerships ([03](03-content-engine.md) §4).
+
+---
+
+## 6. Keyword-splitting discipline (money page vs cost/how-to pillar — anti-cannibalization)
+
+We deliberately run two coordinated assets at **different intents** so they don't compete for the same SERP (we already do this — [02](02-keyword-universe.md) §5A vs §5C, [03](03-content-engine.md) §2B/§2C, and the live pillar `/wedding-photography-cost-in-lahore`):
+
+| Axis | Money page `/wedding-photographers/lahore` | Cost/how-to pillar `/wedding-photography-cost-in-lahore` |
+|---|---|---|
+| **Primary intent** | Commercial — *find & contact* a photographer now | Transactional-info — *research cost / how to choose* before contacting |
+| **Primary keyword** | `wedding photographers in lahore` | `wedding photography cost in lahore` / `wedding photography price` |
+| **Dominant block** | Vendor list (B4) + lead capture (B13) | Deep PKR cost tables + how-to, no vendor grid |
+| **Schema** | CollectionPage/ItemList + LocalBusiness + Review | Article + FAQPage (+ HowTo) |
+| **KPI** | Leads / enquiries / WhatsApp clicks | Referring domains (link magnet) + featured snippets + assisted leads |
+| **Link role** | Receives bridge links from pillar & galleries | Sends a "compare & contact" bridge link → money page (B12a) |
+
+**Why it works:** the two pages answer *different questions*, target *different head terms*, and **cross-link** (pillar → money page CTA; money page B12 → pillar). Google has no reason to pick one over the other, and the informational pillar (a link magnet + AI-citation surface) funnels its research traffic into the commercial page — the informational→commercial bridge that makes informational volume worth chasing ([00-README.md](00-README.md) rule 5, [10](10-resourcing-conversion-risk.md) §2.3). The listicle (`/best/…`) is a *third* intent ("best/ranked") with its own head term, again non-overlapping.
+
+---
+
+## 7. Implementation note (live-system safety)
+
+Every block above is **additive, backward-compatible, flag-gated, zero-downtime**. The money-page template (`components/seo/vendor-type-city-page.tsx`) already emits B0/B3/B5/B11 and the inventory `noindex,follow` guard; this blueprint's deltas (richer `<title>` per §3, answer-first B2, "things to check" B6, "questions to ask" B7, event notes B8, formalized bridges B12) deepen the existing template — they do not rebuild it. Keep the locked URL grammar ([04](04-programmatic-architecture.md) §6), keep the thin-page guards ([04](04-programmatic-architecture.md) §4), and validate schema in CI before any flip.
+
+---
+
+_Created 2026-06-15. Canonical page-level spec; system-level rules defer to [00-README.md](00-README.md). Worked example sourced from live Ubersuggest PK SERP ([briefs/wedding-photographers-lahore-brief.md](briefs/wedding-photographers-lahore-brief.md)). Directional pricing/volumes — re-validate via GSC. Compete for #1; never guarantee it._

--- a/seo-strategy/mega-plan-2yr/TODO.md
+++ b/seo-strategy/mega-plan-2yr/TODO.md
@@ -1,0 +1,131 @@
+# Wedding Wala — Master SEO TODO (the execution checklist toward 1M/mo)
+
+> The single running checklist for the whole program. Detail lives in the mega-plan files [00–10](00-README.md); this file is *what to do, in what order, with which tool*.
+> **Honesty banner:** the goal is pages engineered to **compete for #1** on their primary + secondary keywords. We **maximize** ranking with best-in-class content, on-page, schema, links and speed — but #1 is never *guaranteed* (it depends on authority + time + Google). North star = **organic leads/bookings**, not vanity rank. "Whole Pakistan" = a **tiered, inventory-gated** rollout, never mass thin pages.
+
+**Legend:** ✅ done · 🔄 in progress · ⬜ to do — **P0** = do first/blocking · **P1** = high · **P2** = medium · **P3** = later
+**MCP/skill** column = which tool drives it.
+
+---
+
+## A. Foundation & measurement (Step Zero)
+| ✓ | P | Task | Tool |
+|---|---|------|------|
+| ✅ | P0 | Connect GSC + GA4 + Bing via service account (verified live) | gsc / ga4 / bing-webmaster |
+| ✅ | P0 | Submit sitemap.xml + confirm indexation baseline | gsc |
+| ✅ | P0 | Diagnose canonical "Alternate page" issue (root cause: legacy apex canonical, already fixed; recrawl pending) | gsc |
+| ⬜ | P0 | **Vercel: change apex→www redirect from 307 (temporary) to 301/308 (permanent)** | _user (Vercel dashboard)_ |
+| ⬜ | P0 | Request Indexing in GSC for top money pages (the ~56 stale-canonical pages) | gsc (UI) |
+| ⬜ | P1 | Switch GA4 property to Asia/Karachi timezone + PKR currency | _user (GA4 admin)_ |
+| ⬜ | P1 | Reconnect Claude Code so gsc/ga4 MCP tools load in-session | _user_ |
+| ⬜ | P1 | Define GA4 conversion events (contact reveal / enquiry / WhatsApp click) | ga4 |
+| ⬜ | P2 | Stand up the weekly KPI scorecard + monthly deep-dive ([09](09-measurement-cadence.md)) | gsc / ga4 / bing |
+| ⬜ | P2 | Build Looker Studio dashboard (GA4 + GSC native connectors) | _Looker Studio (no MCP needed)_ |
+
+## B. Keyword planning & research (the demand map)
+| ✓ | P | Task | Tool |
+|---|---|------|------|
+| 🔄 | P0 | Enrich the keyword universe (free-tier only scores ~19/cluster) — pull volume/SD for the full long tail | ubersuggest (keyword_metrics) + GSC |
+| ⬜ | P0 | Build the **{service}×{city} keyword matrix** with primary + secondary per page (every vendor type × every target city) | ubersuggest / serper / GSC |
+| ⬜ | P0 | Classify intent (informational vs commercial vs navigational) per cluster; tier by difficulty (A/B/C) | seo-cluster skill |
+| ⬜ | P1 | Vendor-name navigational keyword list (rank #1 for each vendor's name — the flywheel) | ubersuggest / serper |
+| ⬜ | P1 | Informational cluster maps (mehndi designs, bridal dress, hairstyles, decor, cards) for the blog | ubersuggest / google-trends |
+| ⬜ | P1 | Validate top keyword volumes against **real GSC impressions** once data accrues | gsc |
+| ⬜ | P2 | Seasonal calendar (Decemberistan peak; Eid; 14 August) for content timing | google-trends |
+
+## C. Competitor analysis ("pick top 3 → make ours 100× better")
+| ✓ | P | Task | Tool |
+|---|---|------|------|
+| ⬜ | P0 | For each priority keyword, pull the **live top-3 ranking pages** | serper / g-search |
+| ⬜ | P0 | Scrape + teardown each top-3 page (word count, headings, schema, tables, media, FAQs, internal links, freshness) | firecrawl / fetcher |
+| ⬜ | P0 | Define the **"100× better" spec** per page type (depth + structure + media + schema + E-E-A-T that beats all 3) | seo-content-brief skill |
+| ⬜ | P1 | Full competitor domain teardown: shadiyana.pk, shehnai.pk, others ([10](10-resourcing-conversion-risk.md) §4) | ubersuggest / firecrawl |
+| ⬜ | P1 | Backlink gap analysis — what links competitors have that we don't | seo-backlinks skill / bing-webmaster |
+| ⬜ | P2 | Content-gap map — keywords competitors rank for that we don't cover | ubersuggest / GSC |
+
+## D. Programmatic coverage — "whole Pakistan" (tiered, inventory-gated)
+> Geography model: **Provinces/territories** → Punjab, Sindh, KP, Balochistan, Gilgit-Baltistan, AJK, Islamabad (ICT). **Cities tiered**, NOT all-at-once.
+| ✓ | P | Task | Tool |
+|---|---|------|------|
+| ⬜ | P0 | **City tier list:** Tier-1 metros (KHI, LHR, ISB, RWP) → Tier-2 (Faisalabad, Multan, Sialkot, Gujranwala, Peshawar, Hyderabad, Quetta, Bahawalpur) → Tier-3 long-tail (only with demand + inventory) | constants.ts |
+| ⬜ | P0 | Service catalog: confirm 11 live vendor types + expansion (groom-wear/sherwani, bridal-jewellery, qawwali, choreographers, cakes, salons) | constants.ts |
+| ⬜ | P0 | Province landing pages (`/cities` hub already exists — add province-level hubs linking to their cities) | code (additive) |
+| ⬜ | P1 | Deepen existing {service}×{city} money pages: unique intro per city, PKR ranges, ≥6 vendor cards, FAQ, internal links ([04](04-programmatic-architecture.md) §3) | code |
+| ⬜ | P1 | Vendor profile pages at scale (the navigational flywheel — rank #1 for each vendor name) | code |
+| ⬜ | P0 | **Thin-content guardrail:** keep combos with <3 vendors `noindex,follow` until populated (already enforced — protect it) | code |
+| ⬜ | P2 | Event × city pages (mehndi/barat/walima/mayun/dholki/nikkah × city), variant spellings | code |
+| ⬜ | P2 | Tier-2/Tier-3 city rollout as vendor inventory grows | code + backend |
+
+## E. Blog & content engine (comprehensive, Pakistani audience)
+| ✓ | P | Task | Tool |
+|---|---|------|------|
+| ✅ | P1 | Bridal-dress silo: hub + 4 occasion spokes (walima/barat/mehndi/nikkah) | content-pillar |
+| ⬜ | P0 | **Flagship "100× better" posts** vs the top-3 for the biggest money/info terms (e.g. "Wedding Cost in Pakistan 2026", "Best Wedding Photographers in {city} 2026") | seo-content-brief + content-pillar |
+| ⬜ | P0 | "Best {service} in {city} 2026" listicle program (Tier-1 cities × core services) — the GEO/AI-citation weapon | code (listicle) |
+| ⬜ | P1 | Informational gallery clusters (mehndi designs, bridal looks, decor ideas) — top-of-funnel volume → internal-link to money pages | content-pillar |
+| ⬜ | P1 | Content calendar + publishing velocity ramp ([03](03-content-engine.md) §3) | task-management |
+| ⬜ | P1 | First-party photography to replace Pexels placeholders (E-E-A-T) | _user / shoots_ |
+| ⬜ | P2 | Urdu / Roman-Urdu content layer (en-PK + ur-PK already scaffolded) | code |
+| ⬜ | P2 | Author bylines + E-E-A-T author pages | code |
+
+## F. On-page optimization (per-page checklist — apply to every page)
+| ✓ | P | Task | Tool |
+|---|---|------|------|
+| ⬜ | P0 | Primary keyword in: `<title>`, H1, URL slug, first 100 words, meta description | code |
+| ⬜ | P0 | Secondary keywords split across H2/H3 (one intent per heading) | code |
+| ⬜ | P1 | FAQ section + FAQPage schema targeting "people also ask" long-tail | schema-org |
+| ⬜ | P1 | Internal links: hub→city→vendor + informational→commercial bridge | code |
+| ⬜ | P1 | Image alt text (keyword-aware), WebP, lazy-load, dimensions (CLS) | code |
+| ⬜ | P2 | Tables + answer-first lead (AI-citation friendly) | content-pillar |
+| ⬜ | P2 | "Last updated" + freshness signals | content-pillar |
+
+## G. Technical SEO & GEO (AI search)
+| ✓ | P | Task | Tool |
+|---|---|------|------|
+| ⬜ | P1 | Core Web Vitals / INP audit + fixes (mobile-first PK) | lighthouse / pagespeed / crux |
+| ⬜ | P1 | Schema coverage per page type (LocalBusiness+AggregateRating, ItemList, FAQ, Article, Breadcrumb) | schema-org |
+| ⬜ | P1 | Indexation-at-scale monitoring (coverage, sitemap shard health) | gsc |
+| ⬜ | P2 | IndexNow instant submission (Bing/Yandex) | indexnow |
+| ⬜ | P2 | GEO: answer-first + tables + FAQ + llms.txt for AI Overviews/ChatGPT/Perplexity | seo-geo skill |
+| ⬜ | P2 | hreflang en-PK/ur-PK correctness | code |
+
+## H. Authority & link-building (the #1 lever — DA 1 today)
+| ✓ | P | Task | Tool |
+|---|---|------|------|
+| ⬜ | P0 | Google Business Profile + Bing Places + consistent NAP | _user_ + bing-webmaster |
+| ⬜ | P1 | Foundational PK citations (UrduPoint, directories, socials) | serper / firecrawl |
+| ⬜ | P1 | Vendor reciprocity ("Featured on Wedding Wala" links) | code + outreach |
+| ⬜ | P2 | Digital PR: annual "Pakistan Wedding Season Report" (Decemberistan data) → Dawn/Tribune | google-trends + outreach |
+| ⬜ | P2 | Real-wedding features crediting vendors (backlink manufacturing) | code |
+
+## I. Active sprint (do these next — top of stack)
+1. ⬜ **P0** — Keyword planning: build the {service}×{city} matrix (Section B) for Tier-1 cities.
+2. ⬜ **P0** — Competitor analysis: top-3 teardown + "100× better" spec for the first flagship (Section C).
+3. ⬜ **P0** — Ship the first flagship blog post + first "Best {service} in {city} 2026" listicles.
+4. ⬜ **P0** — Vercel 307→301 + Request Indexing (Section A) — _user actions_.
+
+---
+## J. Whole-Pakistan coverage — EXACT figures (full model: [11-whole-pakistan-coverage.md](11-whole-pakistan-coverage.md))
+> Myth-bust: the "150–300 cities" claim is geographically false — only **127 Pakistani cities exceed 100k people** (2023 PBS census). We target **~32 cities** at full build-out (demand × real inventory), NOT all 127. Expanding from the 12 live today.
+
+| ✓ | P | Task | Detail |
+|---|---|------|--------|
+| ⬜ | P0 | Deepen the **11×12 = 132** live {service}×{city} combos per [12-page-blueprint.md](12-page-blueprint.md) | inventory-backed only |
+| ⬜ | P1 | **Vendor-PROFILE flywheel** — the real indexed-volume driver (**~3,000–6,000+** pages) | scales with onboarding; zero thin risk |
+| ⬜ | P1 | "Best {service} in {city}" listicles — ≥3 vendors, flag-gated (~120–180 indexable) | GEO/AI-citation weapon |
+| ⬜ | P2 | Expand vendor types **11 → ~17** (sherwani, bridal-jewellery, qawwali, choreographers, cakes, salons) | |
+| ⬜ | P2 | Expand cities **12 → ~32** (Tier-3, inventory-gated) | Punjab-first |
+| ⬜ | P2 | Event layer {service}×{city}×{event} + **7 province hubs** (~250–500 indexable) | |
+| ⬜ | P0 | **The hard line:** NEVER mass-publish empty city pages — inventory-gate everything (already coded) | anti-penalty |
+
+**Target indexable pages @ M24:** **~4,145 (Base → ~500k/mo)** to **~7,690 (Aggressive → ~1M/mo ceiling)**. ~9k–15k URLs *generated*, but ~7k stay `noindex,follow` by design. This BEATS the friend's "publish 2,273 doorway pages" approach (a scaled-content-abuse penalty risk).
+
+## K. Adopt the definitive page blueprint ([12-page-blueprint.md](12-page-blueprint.md))
+| ✓ | P | Task | Detail |
+|---|---|------|--------|
+| ✅ | P0 | Template already upgraded with pricing tiers + questions + FAQ schema (Section F) | live in template |
+| ⬜ | P1 | Apply the full **13-block** structure (B0–B13) + **keyword-placement map** to money pages + listicles | primary/secondary/long-tail → exact slot |
+| ⬜ | P2 | Add AggregateRating + Review schema once real review data flows | E-E-A-T |
+
+---
+_Created 2026-06-15. Living file — update status as we execute. Detail & rationale: see [00-README.md](00-README.md) and the mega-plan files. Rankings are competed for, not guaranteed; leads are the north star._

--- a/seo-strategy/mega-plan-2yr/briefs/wedding-photographers-lahore-brief.md
+++ b/seo-strategy/mega-plan-2yr/briefs/wedding-photographers-lahore-brief.md
@@ -1,0 +1,62 @@
+# Content & SEO Brief — "Wedding Photographers in Lahore" (flagship + reusable template)
+
+> Built from the **live Pakistan SERP** (Ubersuggest serp_analysis, locId 2586, 2026-06) + competitor teardown. This is the battle plan for the first flagship — and the **repeatable template for every `{service}×{city}` page** in the whole-Pakistan rollout.
+> Honest note: this engineers the page to **compete for #1**; ranking also needs authority (links) + GBP + time. See [00-README.md](../00-README.md).
+
+## 1. Target keywords
+| Role | Keyword | Vol/mo (PK) | SD | Intent |
+|---|---|---|---|---|
+| **Primary** | wedding photographer lahore | 390 | 18 | commercial |
+| Secondary | best wedding photographer in lahore | (low/mid) | ~18 | commercial |
+| Secondary | wedding photography packages lahore | — | low | transactional |
+| Secondary | wedding photography price in lahore | — | low | transactional |
+| Secondary | wedding photographers in lahore | — | ~18 | commercial |
+| Long-tail | pre wedding shoot photographer lahore / barat photographer lahore | — | low | commercial |
+
+(Volumes directional — Ubersuggest free-tier; re-validate with GSC once data accrues. SD source: master plan.)
+
+## 2. Live SERP reality (who we beat)
+- **Positions 1–3 = Google local pack (GBP/map).** → **Google Business Profile is mandatory** to win this query. (TODO §H)
+- **Top organic = `shadiyana.pk/list/photographers/lahore` — DA22, ~112 clicks.** A directory list ("29 Wedding Photographers in Lahore — Book Now"): vendor cards only, **no pricing, no buyer guide, thin written content.**
+- Studio pages (DA 8–17): `aliabbasiproductions.com` (~1,800 words, portfolio + testimonials but **no pricing, no FAQ, no how-to-choose**), `dclassyclicks.com`, `theweddingstudio.pk`, `camstudio.com.pk` (packages page).
+- Aggregator `wezoree.com` (DA33).
+- **Universal gaps:** transparent PKR pricing · FAQ + schema · "how to choose" guide · comparison tables · answer-first/AI-citation content.
+
+## 3. The "100× better" page spec
+**Two coordinated assets** (directory money page + supporting guide), cross-linked:
+
+### 3A. Money page — `/wedding-photographers/lahore` (deepen the existing programmatic page)
+- Real vendor cards (≥6–10) **with**: PKR price band, rating, review count, specialties (traditional/candid/cinematic), areas served. (Beats shadiyana's no-price list.)
+- Unique 120–180-word Lahore intro (not boilerplate) — neighborhoods (DHA, Gulberg, Johar Town), venues, season.
+- On-page FAQ + **FAQPage schema**; **ItemList** schema for the vendor list; **LocalBusiness + AggregateRating** per vendor.
+- Internal links → the guide (3B), `/wedding-venues/lahore`, `/bridal-makeup-artists/lahore`, bridal-dress silo.
+
+### 3B. Flagship guide (content pillar) — "Wedding Photography in Lahore: Real Costs, Packages & How to Choose (2026)"
+The buyer-intent content **no competitor has**. Structure:
+1. **Answer-first lead** (40–60 words): typical Lahore wedding photography cost range (PKR bands), what drives price. (AI-Overview citable.)
+2. H2 **How much does a wedding photographer cost in Lahore?** → PKR package table (budget / mid / premium / luxury), what each includes (days, edited photos, cinematic film, albums, drone).
+3. H2 **What's included in a wedding photography package** (photo vs cinematography, raw vs edited, deliverables, timelines).
+4. H2 **How to choose a wedding photographer in Lahore** (portfolio consistency, style match, contract, backup gear, team size — checklist).
+5. H2 **Photography by event** (mehndi / barat / walima / nikah — lighting & styling notes).
+6. H2 **Questions to ask before booking** (bulleted; maps to PAA).
+7. H2 **When to book** (3–6 months ahead; Nov–Feb Decemberistan peak).
+8. **FAQ** (8 Q&As → FAQPage schema): "how much…", "advance booking…", "photo vs cinematography…", "drone allowed…", "how many photos…".
+9. CTA → money page (3A) "Compare & contact Lahore wedding photographers."
+- **Honesty:** PKR figures = indicative bands from market research, not Wedding Wala quotes (callout, like the bridal pillars).
+
+## 4. On-page keyword placement (apply every page)
+- Primary in: `<title>`, H1, URL, first 100 words, meta description, one H2.
+- Secondaries split one-per-H2 (packages / price / how-to-choose / by-event).
+- Image alt: "wedding photographer in Lahore — {event} {detail}".
+- Title pattern: **"Wedding Photographers in Lahore — Prices, Packages & Top Studios (2026) | Wedding Wala"**.
+
+## 5. Schema, GEO, local
+- ItemList + LocalBusiness + AggregateRating (money page); FAQPage + Article (guide); BreadcrumbList (both).
+- GEO: answer-first lead + tables + FAQ → AI Overviews/ChatGPT citation.
+- **Local:** create/verify GBP (wins the pos 1–3 pack); consistent NAP.
+
+## 6. Reusability — the template for whole Pakistan
+Swap `{service}` and `{city}` and re-run: `serp_analysis` for `{service} {city}` (top-3 + DA), `keyword_overview` for volumes, teardown via WebFetch/firecrawl, then build money page (3A) + guide (3B). Prioritize Tier-1 cities × core services first (TODO §D).
+
+---
+_Created 2026-06-15. SERP data: Ubersuggest serp_analysis (locId 2586). Directional volumes — re-validate via GSC._


### PR DESCRIPTION
…icing/FAQ upgrade + 2yr plan

- 6 new content pillars: bridal-dress hub + spokes (walima/barat/mehndi/nikkah) and wedding-photography-cost-in-lahore (registry now 38)
- vendor-type-city template: indicative PKR price-tier table, "questions to ask", in-depth guide links, and richer FAQ schema — lifts every city x service money page (additive, inventory-gating preserved)
- lib/seo/pricing-guide.ts: indicative PKR pricing + booking questions for all 11 vendor types
- seo-strategy/mega-plan-2yr: 24-month plan (00-12), whole-Pakistan coverage model, page blueprint, TODO, competitor brief
- chore(security): add .env to .gitignore (was unprotected)