### PR TITLE
feat: vendor claim flow (FE) + SEO enhancements

### DIFF
--- a/app/(dashboard)/dashboard/claims/page.tsx
+++ b/app/(dashboard)/dashboard/claims/page.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import { AdminGuard } from "@/components/admin/AdminGuard"
+import { ClaimsQueueTable } from "@/components/admin/ClaimsQueueTable"
+import PageContainer from "@/components/dashboard/layout/page-container"
+import { PageHeader } from "@/components/dashboard/layout/page-header"
+
+// Super-admin "claim requests" screen. Reviews evidence-path VendorClaim
+// records that landed in pending_review and approves/rejects them. Phone-match
+// claims auto-approve and never reach this queue.
+export default function AdminClaimsPage() {
+  return (
+    <AdminGuard requireSuperAdmin>
+      <PageContainer width="narrow">
+        <PageHeader
+          eyebrow="Admin · Operations"
+          title="Claim requests"
+          description="Vendors proving ownership of imported listings. Approve to hand over the account (a one-time set-password link is emailed), or reject with a reason."
+        />
+        <ClaimsQueueTable />
+      </PageContainer>
+    </AdminGuard>
+  )
+}

--- a/app/(main)/(vendorListings)/layout.tsx
+++ b/app/(main)/(vendorListings)/layout.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from "next"
+
+/**
+ * SEO guard for the app's CLIENT browse/UX surface.
+ *
+ * The `(vendorListings)` group — `/makeup-artists`, `/photographers`,
+ * `/venues`, `/catering`, … and each `/[id]` detail page — is the interactive
+ * browse experience. It PARALLELS the SEO-canonical routes that are actually
+ * built to rank and are the only vendor URLs in the sitemap:
+ *   • type hubs   → `/bridal-makeup-artists`, `/wedding-photographers`,
+ *                    `/wedding-venues`, `/caterers`, `/mehndi-artists`, …
+ *   • city pages  → `/{seo-type}/{city}`
+ *   • vendor leaf → `/{seo-type}/{city}/{name-slug}-{id}`
+ *
+ * These UX pages are `force-dynamic`, thin (a client `<VendorSearch>` / detail
+ * view, no server content or schema), and NOT in the sitemap. Left indexable,
+ * they create thin/duplicate pages competing with the SEO routes and waste
+ * crawl budget on a low-authority domain.
+ *
+ * Fix: `noindex, follow` the whole group. Google still CRAWLS and FOLLOWS the
+ * internal links (so equity flows through to the SEO hubs + vendor profiles),
+ * it just doesn't index these UX pages. Per-page titles/descriptions are
+ * preserved (metadata merges field-by-field); a page may override `robots` if
+ * it should ever be indexed.
+ *
+ * Reference: docs/seo/2026-06-rank-everything/02-EXECUTE.md ("Verified code findings").
+ */
+export const metadata: Metadata = {
+  robots: { index: false, follow: true },
+}
+
+export default function VendorListingsLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/app/(main)/claim/[id]/page.tsx
+++ b/app/(main)/claim/[id]/page.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+// Vendor "claim & complete your listing" wizard route.
+// Linked from the public vendor detail page CTA: `/claim/{vendor.id}`.
+//
+// Flag-gated by NEXT_PUBLIC_CLAIM_ENABLED — when off, a friendly
+// "not available yet" notice renders instead of the wizard.
+
+import { useParams } from "next/navigation"
+
+import { CLAIM_ENABLED } from "@/lib/claim-flag"
+import { ClaimWizard } from "@/components/claim/ClaimWizard"
+import { ClaimDisabledNotice } from "@/components/claim/ClaimDisabledNotice"
+
+export default function ClaimListingPage() {
+  const params = useParams()
+  const id = (params?.id as string) || ""
+
+  if (!CLAIM_ENABLED) {
+    return <ClaimDisabledNotice />
+  }
+
+  return <ClaimWizard listingId={id} />
+}

--- a/app/(main)/claim/set-password/page.tsx
+++ b/app/(main)/claim/set-password/page.tsx
@@ -1,0 +1,27 @@
+import { Suspense } from "react"
+import type { Metadata } from "next"
+import { ClaimSetPasswordForm } from "@/components/claim/ClaimSetPasswordForm"
+
+export const metadata: Metadata = {
+  title: "Set Your Password | Wedding Wala",
+  description: "Finish claiming your listing — set a password for your account.",
+}
+
+// Approved-evidence claimants land here from the emailed one-time link. The
+// page consumes `?token=` and reuses the standard reset-password rails to set
+// the password, then sends them to sign in.
+export default function ClaimSetPasswordPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen bridal-surface bg-bridal-hero flex items-center justify-center">
+          <div className="font-bridal text-bridal-text-soft text-sm">
+            Loading…
+          </div>
+        </div>
+      }
+    >
+      <ClaimSetPasswordForm />
+    </Suspense>
+  )
+}

--- a/components/VendorDetails/VendorDetailsMobile.tsx
+++ b/components/VendorDetails/VendorDetailsMobile.tsx
@@ -47,6 +47,7 @@ import {
 } from "lucide-react";
 import type { Vendor, Review, AvailabilityDay, VendorMenu, Package } from "@/lib/types";
 import { getVendorTypeConfig } from "@/lib/vendor-type-config";
+import { getVendorGuidance } from "@/lib/seo/vendor-type-guidance";
 import Image from "next/image";
 import { BACKEND_URL } from "@/lib/backend-url";
 import { useRouter } from "next/navigation";
@@ -896,8 +897,40 @@ export default function VendorDetailsMobile({
       : 0,
   }));
 
+  // ── Honest enrichment for thin / unclaimed listings ──
+  // No fabricated specifics: copy is true for any vendor of this type+city.
+  const cityName = vendor.location || vendor.city || "Pakistan";
+  const typeName = vendor.type || "wedding vendor";
+  const isThinProfile =
+    (!vendor.packages || vendor.packages.length === 0) &&
+    allReviews.length === 0 &&
+    (!vendor.description || /listed from public records|unclaimed/i.test(vendor.description));
+  const aboutText = isThinProfile
+    ? `${vendor.name} is a ${typeName.toLowerCase()} based in ${cityName}, Pakistan, listed on Wedding Wala. Contact ${vendor.name} to discuss availability, packages and a custom quote for your wedding or event. Verified details and photos are added by the business owner.`
+    : vendor.description || "";
+  // Per-type guidance + FAQ — true, generic, rankable content (no fabrication).
+  const fillCity = (s: string) => s.replace(/\{city\}/g, cityName);
+  const guidance = getVendorGuidance(vendor.type);
+  const guidanceFaqLd = guidance
+    ? {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        mainEntity: guidance.faqs.map((f) => ({
+          "@type": "Question",
+          name: fillCity(f.q),
+          acceptedAnswer: { "@type": "Answer", text: fillCity(f.a) },
+        })),
+      }
+    : null;
+
   return (
     <div className="min-h-screen bg-bridal-ivory">
+      {guidanceFaqLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(guidanceFaqLd) }}
+        />
+      )}
       {/* ===== PARALLAX HERO SECTION ===== */}
       <div
         ref={heroRef}
@@ -1006,10 +1039,14 @@ export default function VendorDetailsMobile({
                   <span className="font-display italic text-[18px]">{(liveAvgRating ?? vendor.rating)?.toFixed(1)}</span>
                   <span className="text-bridal-ivory/70 text-[12px]">({allReviews.length} reviews)</span>
                 </span>
-                <span className="flex items-center gap-2 text-[14px]">
-                  <Shield className="w-4 h-4 text-bridal-sage" />
-                  Verified
-                </span>
+                {(Boolean((vendor as any).emailVerified) ||
+                  Boolean((vendor as any).phoneVerified) ||
+                  Boolean((vendor as any).claimedAt)) && (
+                  <span className="flex items-center gap-2 text-[14px]">
+                    <Shield className="w-4 h-4 text-bridal-sage" />
+                    Verified
+                  </span>
+                )}
               </div>
 
               {/* Price + CTA */}
@@ -1145,15 +1182,65 @@ export default function VendorDetailsMobile({
                     )}
                   </div>
 
-                  {/* Description */}
-                  {vendor.description ? (
+                  {/* About — polished + true. Enriched for thin/unclaimed listings; no fabricated specifics. */}
+                  {aboutText ? (
                     <div className="bg-bridal-cream rounded-md border border-bridal-beige shadow-[0_18px_40px_-32px_rgba(176,125,84,0.35)] p-5">
                       <h2 className="font-display italic text-[20px] text-bridal-charcoal mb-3">About</h2>
                       <p className="text-sm text-bridal-charcoal/85 leading-relaxed break-words">
-                        {vendor.description}
+                        {aboutText}
                       </p>
+                      {isThinProfile && (
+                        <div className="mt-4 flex flex-col sm:flex-row sm:items-center gap-3 rounded-md border border-bridal-gold/40 bg-bridal-ivory px-4 py-3">
+                          <div className="flex-1 min-w-0">
+                            <p className="font-bridal text-[13px] font-semibold text-bridal-charcoal">Is this your business?</p>
+                            <p className="font-bridal text-[12.5px] text-bridal-text-soft">Claim this listing to add your packages, prices and real photos.</p>
+                          </div>
+                          <Link
+                            href={`/claim/${vendor.id}`}
+                            className="inline-flex items-center justify-center px-4 py-2 rounded-full bg-bridal-gold text-bridal-charcoal hover:bg-bridal-gold-dark hover:text-bridal-ivory font-bridal text-[11px] uppercase tracking-[0.18em] font-medium transition-colors whitespace-nowrap"
+                          >
+                            Claim this listing
+                          </Link>
+                        </div>
+                      )}
                     </div>
                   ) : null}
+
+                  {/* Category guidance + FAQ — true, helpful, rankable (no fabrication). Shown on every page. */}
+                  {guidance && (
+                    <div className="bg-bridal-cream rounded-md border border-bridal-beige shadow-[0_18px_40px_-32px_rgba(176,125,84,0.35)] p-5 space-y-5">
+                      <div>
+                        <h3 className="font-display italic text-[20px] text-bridal-charcoal mb-2">
+                          Booking a {typeName.toLowerCase()} in {cityName}
+                        </h3>
+                        <p className="text-sm text-bridal-charcoal/85 leading-relaxed break-words">
+                          {fillCity(guidance.intro)}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="font-bridal text-[11px] uppercase tracking-[0.22em] font-medium text-bridal-gold-dark mb-2.5">What to ask</p>
+                        <ul className="space-y-2">
+                          {guidance.ask.map((a, i) => (
+                            <li key={i} className="flex gap-2 text-sm text-bridal-charcoal/85 leading-relaxed">
+                              <CheckCircle className="w-4 h-4 mt-0.5 shrink-0 text-bridal-gold" />
+                              <span>{fillCity(a)}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                      <div>
+                        <p className="font-bridal text-[11px] uppercase tracking-[0.22em] font-medium text-bridal-gold-dark mb-2.5">Frequently asked</p>
+                        <dl className="space-y-3">
+                          {guidance.faqs.map((f, i) => (
+                            <div key={i}>
+                              <dt className="font-bridal text-[14px] font-semibold text-bridal-charcoal">{fillCity(f.q)}</dt>
+                              <dd className="mt-1 text-sm text-bridal-charcoal/85 leading-relaxed break-words">{fillCity(f.a)}</dd>
+                            </div>
+                          ))}
+                        </dl>
+                      </div>
+                    </div>
+                  )}
 
                   {/* subBusinessType — multi-select types (Photographer, Decorator, Henna, Makeup) */}
                   {isSubBizTypeMulti && subBizTypeValues.length > 0 && (
@@ -1866,9 +1953,25 @@ export default function VendorDetailsMobile({
                       </StaggerItem>
                     ))
                   ) : (
-                    <p className="text-sm text-bridal-text-soft text-center py-6">
-                      No packages available yet. Contact the vendor for pricing.
-                    </p>
+                    <div className="rounded-md border border-bridal-beige bg-bridal-cream p-6 sm:p-8 text-center shadow-[0_18px_40px_-32px_rgba(176,125,84,0.35)]">
+                      <div className="mx-auto mb-3 inline-flex h-12 w-12 items-center justify-center rounded-full bg-bridal-gold/15 text-bridal-gold-dark">
+                        <PackageIcon className="h-5 w-5" />
+                      </div>
+                      <p className="font-display italic text-[20px] text-bridal-charcoal">Pricing on request</p>
+                      <p className="mx-auto mt-2 max-w-md font-bridal text-[13.5px] text-bridal-text-soft leading-relaxed">
+                        {vendor.name} tailors packages to your date, guest count and requirements.
+                        Share your details to get a custom quote — no obligation.
+                      </p>
+                      <div className="mt-5 flex justify-center">
+                        <button
+                          type="button"
+                          onClick={handleMessageVendor}
+                          className="inline-flex items-center justify-center gap-2 h-11 px-7 rounded-[4px] bg-bridal-gold hover:bg-bridal-gold-dark text-bridal-charcoal hover:text-bridal-ivory font-bridal text-[12px] uppercase tracking-[0.2em] font-medium transition-colors"
+                        >
+                          <MessageCircle className="w-4 h-4" /> Request pricing
+                        </button>
+                      </div>
+                    </div>
                   )}
                 </StaggerContainer>
               )}
@@ -1958,7 +2061,8 @@ export default function VendorDetailsMobile({
                 </div>
               </ScrollReveal>
 
-              {/* Review summary */}
+              {/* Review summary — only when there are real reviews (honest empty state shown below) */}
+              {allReviews.length > 0 && (
               <ScrollReveal>
                 <Card className="border-bridal-beige mb-6">
                   <CardContent className="p-6">
@@ -1985,6 +2089,7 @@ export default function VendorDetailsMobile({
                   </CardContent>
                 </Card>
               </ScrollReveal>
+              )}
 
               {/* Write a review */}
               {isAuthenticated && userBookingId && !alreadyReviewed && (
@@ -2054,9 +2159,16 @@ export default function VendorDetailsMobile({
                 </div>
               )}
               {!reviewsLoading && allReviews.length === 0 && (
-                <p className="text-sm text-bridal-text-soft text-center py-8">
-                  No reviews yet. Be the first to book and leave a review!
-                </p>
+                <div className="rounded-md border border-bridal-beige bg-bridal-cream p-6 sm:p-8 text-center shadow-[0_18px_40px_-32px_rgba(176,125,84,0.35)]">
+                  <div className="mx-auto mb-3 inline-flex h-12 w-12 items-center justify-center rounded-full bg-bridal-gold/15 text-bridal-gold-dark">
+                    <Star className="h-5 w-5" />
+                  </div>
+                  <p className="font-display italic text-[20px] text-bridal-charcoal">No reviews yet</p>
+                  <p className="mx-auto mt-2 max-w-md font-bridal text-[13.5px] text-bridal-text-soft leading-relaxed">
+                    Reviews on Wedding Wala come only from verified, completed bookings — so every rating
+                    you see is real. Be the first to book {vendor.name} and share your experience.
+                  </p>
+                </div>
               )}
               <StaggerContainer staggerDelay={0.1} className="space-y-4">
                 {allReviews.map((review) => (

--- a/components/admin/ClaimsQueueTable.tsx
+++ b/components/admin/ClaimsQueueTable.tsx
@@ -1,0 +1,288 @@
+"use client"
+
+// Admin "claim requests" queue. Lists VendorClaim records from
+// GET /api/v1/claims/admin/claims and lets a super-admin Approve (emails the
+// claimant a set-password link) or Reject (with a reason). Refreshes after
+// each action. Auth header is attached automatically by axiosConfig.
+
+import { useEffect, useState } from "react"
+import { CheckCircle2, XCircle, Loader2, FileText, Phone, Mail } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from "@/components/ui/dialog"
+import { toast } from "@/components/ui/use-toast"
+import {
+  listClaims,
+  approveClaim,
+  rejectClaim,
+  type AdminClaim,
+  type ClaimStatus,
+} from "@/lib/api/claims"
+
+const STATUS_TABS: { value: ClaimStatus; label: string }[] = [
+  { value: "pending_review", label: "Awaiting review" },
+  { value: "approved", label: "Approved" },
+  { value: "rejected", label: "Rejected" },
+  { value: "auto_approved", label: "Auto-approved" },
+]
+
+const METHOD_LABEL: Record<AdminClaim["method"], string> = {
+  phone_match: "Phone match",
+  evidence: "Evidence",
+}
+
+interface PendingAction {
+  kind: "approve" | "reject"
+  claim: AdminClaim
+}
+
+function businessName(c: AdminClaim): string {
+  return c.business?.name || c.listing?.name || `Listing #${c.businessId}`
+}
+
+export function ClaimsQueueTable() {
+  const [statusTab, setStatusTab] = useState<ClaimStatus>("pending_review")
+  const [claims, setClaims] = useState<AdminClaim[]>([])
+  const [loading, setLoading] = useState(true)
+  const [pendingAction, setPendingAction] = useState<PendingAction | null>(null)
+  const [reason, setReason] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+
+  const refresh = async () => {
+    try {
+      setLoading(true)
+      const rows = await listClaims(statusTab)
+      setClaims(rows)
+    } catch (e: any) {
+      toast({
+        title: "Failed to load claims",
+        description: e?.response?.data?.message || "Try again.",
+      })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    refresh()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [statusTab])
+
+  const performAction = async () => {
+    if (!pendingAction) return
+    const { kind, claim } = pendingAction
+    if (kind === "reject" && !reason.trim()) {
+      toast({ title: "Reason required", description: "Please add a rejection reason." })
+      return
+    }
+    setSubmitting(true)
+    try {
+      if (kind === "approve") {
+        await approveClaim(claim.id)
+        toast({
+          title: "Claim approved",
+          description: `${businessName(claim)} — a set-password link was emailed to the claimant.`,
+        })
+      } else {
+        await rejectClaim(claim.id, reason.trim())
+        toast({ title: "Claim rejected", description: businessName(claim) })
+      }
+      setPendingAction(null)
+      setReason("")
+      await refresh()
+    } catch (e: any) {
+      toast({
+        title: "Action failed",
+        description: e?.response?.data?.message || "Try again.",
+      })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <Tabs value={statusTab} onValueChange={(v) => setStatusTab(v as ClaimStatus)}>
+        <TabsList>
+          {STATUS_TABS.map((t) => (
+            <TabsTrigger key={t.value} value={t.value}>
+              {t.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">
+            {claims.length} {claims.length === 1 ? "claim" : "claims"}{" "}
+            {statusTab.replace("_", " ")}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="flex items-center gap-2 text-sm text-bridal-text-soft py-6">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Loading…
+            </div>
+          ) : claims.length === 0 ? (
+            <p className="text-sm text-bridal-text-soft py-6 text-center">
+              No claims in this state.
+            </p>
+          ) : (
+            <div className="space-y-3">
+              {claims.map((c) => (
+                <div
+                  key={c.id}
+                  className="rounded-md border border-bridal-beige/70 p-4 flex flex-col gap-3"
+                >
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="font-medium text-bridal-charcoal">
+                        {businessName(c)}
+                      </div>
+                      <div className="text-xs text-bridal-text-soft">
+                        {c.business?.city || "—"} · Listing #{c.businessId}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-2 shrink-0">
+                      <span className="text-[11px] font-medium uppercase tracking-[0.08em] px-2 py-0.5 rounded-full bg-bridal-beige/50 text-bridal-text-soft">
+                        {METHOD_LABEL[c.method] || c.method}
+                      </span>
+                      <span className="text-xs text-bridal-text-soft">
+                        {new Date(c.createdAt).toLocaleDateString()}
+                      </span>
+                    </div>
+                  </div>
+
+                  {/* Claimant */}
+                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 text-sm">
+                    <div className="min-w-0">
+                      <div className="text-bridal-charcoal truncate">
+                        {c.claimantName || "—"}
+                      </div>
+                      <div className="text-xs text-bridal-text-soft">Claimant</div>
+                    </div>
+                    <div className="min-w-0 flex items-center gap-1.5 text-bridal-text-soft">
+                      <Mail className="w-3.5 h-3.5 shrink-0" />
+                      <span className="truncate">{c.claimantEmail || "—"}</span>
+                    </div>
+                    <div className="min-w-0 flex items-center gap-1.5 text-bridal-text-soft">
+                      <Phone className="w-3.5 h-3.5 shrink-0" />
+                      <span className="truncate">{c.claimantPhoneE164 || "—"}</span>
+                    </div>
+                  </div>
+
+                  {/* Evidence */}
+                  {c.evidenceNote && (
+                    <div className="rounded-md bg-bridal-ivory border border-bridal-beige/60 p-3">
+                      <div className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-[0.08em] text-bridal-text-soft mb-1">
+                        <FileText className="w-3.5 h-3.5" />
+                        Evidence
+                      </div>
+                      <p className="text-sm text-bridal-charcoal/90 whitespace-pre-wrap break-words">
+                        {c.evidenceNote}
+                      </p>
+                      {c.evidenceDocUrl && (
+                        <a
+                          href={c.evidenceDocUrl}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="inline-block mt-2 text-xs text-bridal-gold-dark underline underline-offset-2"
+                        >
+                          View attached document
+                        </a>
+                      )}
+                    </div>
+                  )}
+
+                  {c.status === "rejected" && c.rejectionReason && (
+                    <p className="text-xs text-bridal-coral">
+                      Rejected: {c.rejectionReason}
+                    </p>
+                  )}
+
+                  {/* Actions — only for pending review */}
+                  {c.status === "pending_review" && (
+                    <div className="flex flex-wrap gap-2 justify-end">
+                      <Button
+                        size="sm"
+                        variant="default"
+                        onClick={() => {
+                          setPendingAction({ kind: "approve", claim: c })
+                          setReason("")
+                        }}
+                      >
+                        <CheckCircle2 className="w-3.5 h-3.5 mr-1" />
+                        Approve
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="destructive"
+                        onClick={() => {
+                          setPendingAction({ kind: "reject", claim: c })
+                          setReason("")
+                        }}
+                      >
+                        <XCircle className="w-3.5 h-3.5 mr-1" />
+                        Reject
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Confirmation dialog */}
+      <Dialog open={!!pendingAction} onOpenChange={(o) => !o && setPendingAction(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="capitalize">
+              {pendingAction?.kind} —{" "}
+              {pendingAction ? businessName(pendingAction.claim) : ""}
+            </DialogTitle>
+            <DialogDescription>
+              {pendingAction?.kind === "approve"
+                ? "On approval the listing is handed over and a one-time set-password link is emailed to the claimant."
+                : "The claimant is notified. Add a clear reason — it may be emailed to them."}
+            </DialogDescription>
+          </DialogHeader>
+
+          {pendingAction?.kind === "reject" && (
+            <Textarea
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="Reason for rejection (required)"
+              rows={4}
+            />
+          )}
+
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setPendingAction(null)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={performAction}
+              disabled={submitting}
+              variant={pendingAction?.kind === "reject" ? "destructive" : "default"}
+            >
+              {submitting ? "Working…" : "Confirm"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/components/claim/ClaimDisabledNotice.tsx
+++ b/components/claim/ClaimDisabledNotice.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+// Shown at /claim/[id] when NEXT_PUBLIC_CLAIM_ENABLED is not "true". Keeps the
+// route navigable (no 404) but tells the visitor the feature is dark-shipped.
+
+import Link from "next/link"
+import { Clock } from "lucide-react"
+
+import { BridalCrown, BridalTitle } from "@/components/bridal/bridal-card"
+import { FloralDivider } from "@/components/bridal/floral-divider"
+
+export function ClaimDisabledNotice() {
+  return (
+    <div className="min-h-screen bridal-surface relative overflow-hidden">
+      <div className="absolute inset-0 bg-bridal-hero" aria-hidden />
+      <div className="absolute inset-0 bg-bridal-wash opacity-95" aria-hidden />
+
+      <div className="relative z-10 flex items-center justify-center min-h-screen px-4 sm:px-6 py-12">
+        <div className="w-full max-w-[460px] animate-stagger-fade-up">
+          <div className="bridal-card bg-bridal-cream border border-bridal-beige shadow-[0_24px_50px_-30px_rgba(176,125,84,0.5)] rounded-md p-6 sm:p-8 text-center">
+            <div className="mx-auto mb-5 w-16 h-16 rounded-full bg-bridal-gold/15 border border-bridal-gold/40 flex items-center justify-center">
+              <Clock className="w-7 h-7 text-bridal-gold-dark" />
+            </div>
+            <BridalCrown className="mb-3">Coming Soon</BridalCrown>
+            <BridalTitle size="h2" className="mb-3">
+              Claiming is{" "}
+              <span className="text-bridal-gold">not available yet</span>
+            </BridalTitle>
+            <p className="font-bridal text-bridal-text-soft text-sm mb-7">
+              We&apos;re putting the finishing touches on listing claims. Please
+              check back soon — in the meantime you can browse vendors or get in
+              touch.
+            </p>
+            <Link
+              href="/vendors"
+              className="inline-flex w-full items-center justify-center h-12 px-8 rounded-[4px] bg-bridal-gold text-bridal-charcoal hover:bg-bridal-gold-dark hover:text-bridal-ivory font-bridal font-medium text-sm uppercase tracking-[0.2em] shadow-[0_8px_22px_-12px_rgba(176,125,84,0.55)] hover:shadow-[0_12px_28px_-12px_rgba(176,125,84,0.7)] transition-all duration-250"
+            >
+              Browse Vendors
+            </Link>
+
+            <div className="my-6">
+              <FloralDivider />
+            </div>
+
+            <p className="font-bridal text-sm text-bridal-text-soft">
+              Questions?{" "}
+              <Link
+                href="/contact"
+                className="text-bridal-gold hover:text-bridal-gold-dark font-medium underline-offset-4 hover:underline transition-colors"
+              >
+                Contact us
+              </Link>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/claim/ClaimSetPasswordForm.tsx
+++ b/components/claim/ClaimSetPasswordForm.tsx
@@ -1,0 +1,322 @@
+"use client"
+
+// Claim "set password" — for approved evidence-path claims. Mirrors the
+// existing reset-password form (components/reset-password-form.tsx) and reuses
+// the same backend rails: POST /api/v1/auth/reset-password { token, password }.
+// The token arrives via the emailed one-time link as `?token=`.
+
+import { useMemo, useState } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import * as z from "zod"
+import Link from "next/link"
+import { useRouter, useSearchParams } from "next/navigation"
+import {
+  ArrowLeft,
+  Lock,
+  Eye,
+  EyeOff,
+  CheckCircle2,
+  ShieldAlert,
+  KeyRound,
+} from "lucide-react"
+
+import axiosInstance from "@/lib/axiosConfig"
+import { toast } from "@/components/ui/use-toast"
+
+import { BridalButton } from "@/components/bridal/bridal-button"
+import { BridalField, BridalInput } from "@/components/bridal/bridal-input"
+import { BridalCrown, BridalTitle } from "@/components/bridal/bridal-card"
+import { FloralDivider } from "@/components/bridal/floral-divider"
+import { AuthShell, AuthAsideChecklist } from "@/components/bridal/auth-shell"
+
+const formSchema = z
+  .object({
+    password: z
+      .string()
+      .min(8, { message: "Password must be at least 8 characters" }),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  })
+
+type FormData = z.infer<typeof formSchema>
+
+function strengthScore(p: string): number {
+  if (!p) return 0
+  let s = 0
+  if (p.length >= 8) s++
+  if (p.length >= 12) s++
+  if (/[a-z]/.test(p) && /[A-Z]/.test(p)) s++
+  if (/\d/.test(p)) s++
+  if (/[^a-zA-Z0-9]/.test(p)) s++
+  return Math.min(s, 4)
+}
+
+const STRENGTH_LABELS = ["Too short", "Weak", "Fair", "Good", "Strong"]
+const STRENGTH_HUES = [
+  "bg-bridal-coral",
+  "bg-bridal-coral",
+  "bg-bridal-gold",
+  "bg-bridal-sage",
+  "bg-[#3F6B43]",
+]
+
+export function ClaimSetPasswordForm() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const token = searchParams?.get("token") || searchParams?.get("t") || ""
+
+  const [isLoading, setIsLoading] = useState(false)
+  const [showPassword, setShowPassword] = useState(false)
+  const [showConfirm, setShowConfirm] = useState(false)
+  const [done, setDone] = useState(false)
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<FormData>({ resolver: zodResolver(formSchema) })
+
+  const newPassword = watch("password") || ""
+  const score = useMemo(() => strengthScore(newPassword), [newPassword])
+
+  const onSubmit = async (data: FormData) => {
+    if (!token) return
+    try {
+      setIsLoading(true)
+      await axiosInstance.post("/api/v1/auth/reset-password", {
+        token,
+        password: data.password,
+      })
+      setDone(true)
+      toast({
+        title: "Password set",
+        description: "Your listing is claimed — sign in to manage it.",
+      })
+      setTimeout(() => router.push("/login"), 2200)
+    } catch (err: any) {
+      toast({
+        title: "Couldn't set password",
+        description:
+          err?.response?.data?.message ||
+          "The link may have expired. Please request a new one.",
+        variant: "destructive",
+      })
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const checklistItems = [
+    { icon: <CheckCircle2 className="w-4 h-4" />, label: "8+ characters" },
+    { icon: <CheckCircle2 className="w-4 h-4" />, label: "Letters & numbers" },
+    { icon: <CheckCircle2 className="w-4 h-4" />, label: "Mix the case" },
+    { icon: <CheckCircle2 className="w-4 h-4" />, label: "A symbol or two" },
+  ]
+
+  return (
+    <AuthShell
+      variant="reset"
+      asideAlt="Wedding florals"
+      asideBadge={{
+        icon: <KeyRound className="w-3 h-3" />,
+        label: "Claim Approved",
+      }}
+      asideTitle={
+        <>
+          Your listing is{" "}
+          <span className="text-bridal-rose">yours.</span>
+        </>
+      }
+      asideSubtitle="Set a password to finish claiming your business. Then sign in to add your packages, prices and real photos."
+      asideExtra={<AuthAsideChecklist items={checklistItems} />}
+      mobileCrestIcon={<KeyRound className="w-5 h-5 text-bridal-gold" />}
+    >
+      {/* ── Missing-token guard ── */}
+      {!token ? (
+        <div className="text-center">
+          <div className="mx-auto mb-5 w-16 h-16 rounded-full bg-bridal-coral/20 border border-bridal-coral/40 flex items-center justify-center">
+            <ShieldAlert className="w-7 h-7 text-[#9B4A38]" />
+          </div>
+          <BridalCrown className="mb-3">Link Invalid</BridalCrown>
+          <BridalTitle size="h2" className="mb-3">
+            This link is{" "}
+            <span className="text-bridal-coral">missing or expired</span>
+          </BridalTitle>
+          <p className="font-bridal text-bridal-text-soft text-sm mb-7">
+            The set-password link in your approval email may have expired.
+            Please contact us and we&apos;ll send a fresh one.
+          </p>
+          <BridalButton
+            variant="primary"
+            size="lg"
+            block
+            onClick={() => router.push("/contact")}
+          >
+            Contact Us
+          </BridalButton>
+          <div className="my-7">
+            <FloralDivider />
+          </div>
+          <Link
+            href="/login"
+            className="inline-flex items-center gap-1.5 font-bridal text-sm text-bridal-mauve hover:text-bridal-gold transition-colors"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Back to sign in
+          </Link>
+        </div>
+      ) : done ? (
+        // ── Success state ───────────────────────────────────────────
+        <div className="text-center">
+          <div className="mx-auto mb-5 w-16 h-16 rounded-full bg-bridal-sage/20 border border-bridal-sage/40 flex items-center justify-center">
+            <CheckCircle2 className="w-7 h-7 text-[#3F6B43]" />
+          </div>
+          <BridalCrown className="mb-3">All Set</BridalCrown>
+          <BridalTitle size="h2" className="mb-3">
+            Your password has been{" "}
+            <span className="text-bridal-gold">set</span>
+          </BridalTitle>
+          <p className="font-bridal text-bridal-text-soft text-sm mb-7">
+            Redirecting you to sign in…
+          </p>
+          <BridalButton
+            variant="primary"
+            size="lg"
+            block
+            onClick={() => router.push("/login")}
+          >
+            Continue to Sign In
+          </BridalButton>
+        </div>
+      ) : (
+        // ── Set-password form ───────────────────────────────────────
+        <>
+          <BridalCrown className="mb-3">Set Password</BridalCrown>
+          <BridalTitle size="h2" className="text-center mb-2">
+            Choose a <span className="text-bridal-gold">password</span>
+          </BridalTitle>
+          <p className="text-center font-bridal text-bridal-text-soft text-sm mb-7">
+            Pick something strong and memorable — you&apos;ll use it to sign in
+            and manage your listing.
+          </p>
+
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+            <BridalField
+              id="password"
+              label="New Password"
+              error={errors.password?.message}
+              required
+            >
+              <BridalInput
+                id="password"
+                type={showPassword ? "text" : "password"}
+                autoCapitalize="none"
+                autoComplete="new-password"
+                placeholder="At least 8 characters"
+                leadingIcon={<Lock className="w-4 h-4" />}
+                invalid={!!errors.password}
+                trailing={
+                  <button
+                    type="button"
+                    tabIndex={-1}
+                    onClick={() => setShowPassword((p) => !p)}
+                    className="w-8 h-8 inline-flex items-center justify-center rounded-full text-bridal-text-label hover:text-bridal-mauve hover:bg-bridal-blush/60 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-bridal-gold/50"
+                    aria-label={showPassword ? "Hide password" : "Show password"}
+                  >
+                    {showPassword ? (
+                      <EyeOff className="w-4 h-4" />
+                    ) : (
+                      <Eye className="w-4 h-4" />
+                    )}
+                  </button>
+                }
+                {...register("password")}
+              />
+            </BridalField>
+
+            {newPassword && (
+              <div className="space-y-1.5">
+                <div className="flex gap-1">
+                  {[0, 1, 2, 3].map((i) => (
+                    <div
+                      key={i}
+                      className={`flex-1 h-1 rounded-full transition-colors duration-300 ${
+                        i < score ? STRENGTH_HUES[score] : "bg-bridal-beige"
+                      }`}
+                    />
+                  ))}
+                </div>
+                <p className="font-bridal text-[11px] uppercase tracking-[0.18em] text-bridal-text-soft">
+                  {STRENGTH_LABELS[score]}
+                </p>
+              </div>
+            )}
+
+            <BridalField
+              id="confirmPassword"
+              label="Confirm Password"
+              error={errors.confirmPassword?.message}
+              required
+            >
+              <BridalInput
+                id="confirmPassword"
+                type={showConfirm ? "text" : "password"}
+                autoCapitalize="none"
+                autoComplete="new-password"
+                placeholder="Repeat your new password"
+                leadingIcon={<CheckCircle2 className="w-4 h-4" />}
+                invalid={!!errors.confirmPassword}
+                trailing={
+                  <button
+                    type="button"
+                    tabIndex={-1}
+                    onClick={() => setShowConfirm((p) => !p)}
+                    className="w-8 h-8 inline-flex items-center justify-center rounded-full text-bridal-text-label hover:text-bridal-mauve hover:bg-bridal-blush/60 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-bridal-gold/50"
+                    aria-label={showConfirm ? "Hide password" : "Show password"}
+                  >
+                    {showConfirm ? (
+                      <EyeOff className="w-4 h-4" />
+                    ) : (
+                      <Eye className="w-4 h-4" />
+                    )}
+                  </button>
+                }
+                {...register("confirmPassword")}
+              />
+            </BridalField>
+
+            <BridalButton
+              type="submit"
+              variant="primary"
+              size="lg"
+              block
+              loading={isLoading}
+              className="mt-2"
+            >
+              {isLoading ? "Saving…" : "Set Password"}
+            </BridalButton>
+          </form>
+
+          <div className="my-7">
+            <FloralDivider />
+          </div>
+
+          <p className="text-center font-bridal text-sm text-bridal-text-soft">
+            Already set up?{" "}
+            <Link
+              href="/login"
+              className="text-bridal-gold hover:text-bridal-gold-dark font-medium underline-offset-4 hover:underline transition-colors"
+            >
+              Sign in
+            </Link>
+          </p>
+        </>
+      )}
+    </AuthShell>
+  )
+}

--- a/components/claim/ClaimWizard.tsx
+++ b/components/claim/ClaimWizard.tsx
@@ -1,0 +1,589 @@
+"use client"
+
+// Vendor "claim & complete your listing" — 3-step wizard.
+//
+//   Step A (contact)   → POST /start              → store claimId, go to OTP
+//   Step B (OTP)       → POST /:id/verify         → branch on data.next:
+//      • "set_password" → Step C
+//      • "evidence"     → Step D
+//   Step C (password)  → POST /:id/finalize       → login() + /dashboard
+//   Step D (evidence)  → POST /:id/evidence       → success panel
+//
+// Flag-gated by NEXT_PUBLIC_CLAIM_ENABLED (see lib/claim-flag.ts) — when off,
+// the page shows a "Claiming is not available yet" notice instead of mounting
+// this component.
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import Link from "next/link"
+import {
+  User as UserIcon,
+  Mail,
+  Phone,
+  Lock,
+  Eye,
+  EyeOff,
+  CheckCircle2,
+  ShieldCheck,
+  KeyRound,
+  FileText,
+  ArrowLeft,
+  Sparkles,
+} from "lucide-react"
+
+import { useUser } from "@/context/UserContext"
+import { toast } from "@/components/ui/use-toast"
+import {
+  startClaim,
+  verifyClaim,
+  finalizeClaim,
+  submitClaimEvidence,
+} from "@/lib/api/claims"
+
+import { BridalButton } from "@/components/bridal/bridal-button"
+import { BridalField, BridalInput } from "@/components/bridal/bridal-input"
+import { BridalCrown, BridalTitle } from "@/components/bridal/bridal-card"
+import { FloralDivider } from "@/components/bridal/floral-divider"
+
+type Step = "contact" | "otp" | "password" | "evidence" | "submitted"
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+function apiMessage(err: any, fallback: string): string {
+  return err?.response?.data?.message || fallback
+}
+
+// Visual step rail (contact → verify → finish). The set-password and evidence
+// branches both map to the third "finish" pip.
+function StepRail({ step }: { step: Step }) {
+  const index =
+    step === "contact" ? 0 : step === "otp" ? 1 : 2
+  const labels = ["Your details", "Verify", "Finish"]
+  return (
+    <div className="flex items-center justify-center gap-2 mb-6">
+      {labels.map((label, i) => (
+        <div key={label} className="flex items-center gap-2">
+          <div
+            className={`flex items-center gap-2 px-2.5 py-1 rounded-full font-bridal text-[10px] uppercase tracking-[0.18em] font-medium transition-colors ${
+              i <= index
+                ? "bg-bridal-gold/15 text-bridal-gold-dark"
+                : "bg-bridal-beige/40 text-bridal-text-label"
+            }`}
+          >
+            <span
+              className={`inline-flex items-center justify-center w-4 h-4 rounded-full text-[9px] ${
+                i < index
+                  ? "bg-bridal-gold text-bridal-charcoal"
+                  : i === index
+                    ? "bg-bridal-gold/30 text-bridal-gold-dark border border-bridal-gold/60"
+                    : "bg-bridal-beige text-bridal-text-label"
+              }`}
+            >
+              {i < index ? "✓" : i + 1}
+            </span>
+            <span className="hidden sm:inline">{label}</span>
+          </div>
+          {i < labels.length - 1 && (
+            <span className="w-4 h-px bg-bridal-beige" aria-hidden />
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function ClaimWizard({ listingId }: { listingId: string }) {
+  const router = useRouter()
+  const { login } = useUser()
+
+  const [step, setStep] = useState<Step>("contact")
+  const [submitting, setSubmitting] = useState(false)
+
+  // Step A — contact
+  const [name, setName] = useState("")
+  const [email, setEmail] = useState("")
+  const [phone, setPhone] = useState("")
+  const [contactError, setContactError] = useState<string | null>(null)
+
+  // Carried between steps
+  const [claimId, setClaimId] = useState<number | null>(null)
+  const [otpSentTo, setOtpSentTo] = useState("")
+
+  // Step B — OTP
+  const [code, setCode] = useState("")
+  const [otpError, setOtpError] = useState<string | null>(null)
+
+  // Step C — set password
+  const [password, setPassword] = useState("")
+  const [confirm, setConfirm] = useState("")
+  const [showPassword, setShowPassword] = useState(false)
+  const [showConfirm, setShowConfirm] = useState(false)
+  const [passwordError, setPasswordError] = useState<string | null>(null)
+
+  // Step D — evidence
+  const [evidenceNote, setEvidenceNote] = useState("")
+  const [evidenceError, setEvidenceError] = useState<string | null>(null)
+
+  // ── Step A submit ────────────────────────────────────────────────────────
+  const onContactSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setContactError(null)
+    if (!name.trim()) return setContactError("Please enter your name.")
+    if (!EMAIL_RE.test(email.trim()))
+      return setContactError("Please enter a valid email address.")
+    if (phone.trim().length < 7)
+      return setContactError("Please enter a valid phone number.")
+
+    setSubmitting(true)
+    try {
+      const res = await startClaim({
+        listingId,
+        name: name.trim(),
+        email: email.trim(),
+        phone: phone.trim(),
+      })
+      setClaimId(res.claimId)
+      setOtpSentTo(res.otpSentTo || phone.trim())
+      setCode("")
+      setStep("otp")
+      toast({
+        title: "Code sent",
+        description: `We sent a 6-digit code to ${res.otpSentTo || "your phone"}.`,
+      })
+    } catch (err: any) {
+      setContactError(
+        apiMessage(err, "We couldn't start the claim. Please try again.")
+      )
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  // ── Step B submit ────────────────────────────────────────────────────────
+  const onOtpSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setOtpError(null)
+    if (code.length !== 6) return setOtpError("Enter the 6-digit code.")
+    if (!claimId) return setOtpError("Your session expired. Please restart.")
+
+    setSubmitting(true)
+    try {
+      const { next } = await verifyClaim(claimId, code)
+      if (next === "set_password") {
+        setStep("password")
+      } else {
+        setStep("evidence")
+      }
+    } catch (err: any) {
+      setOtpError(
+        apiMessage(err, "That code wasn't right. Please check and try again.")
+      )
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  // ── Step C submit (phone-match takeover) ─────────────────────────────────
+  const onPasswordSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setPasswordError(null)
+    if (password.length < 8)
+      return setPasswordError("Password must be at least 8 characters.")
+    if (password !== confirm)
+      return setPasswordError("Passwords do not match.")
+    if (!claimId) return setPasswordError("Your session expired. Please restart.")
+
+    setSubmitting(true)
+    try {
+      const { user, token, jti } = await finalizeClaim(claimId, password)
+      login(user, token, { jti })
+      toast({
+        title: "Listing claimed",
+        description: "Welcome — your business is now yours to manage.",
+      })
+      router.push("/dashboard")
+    } catch (err: any) {
+      setPasswordError(
+        apiMessage(err, "We couldn't finish the claim. Please try again.")
+      )
+      setSubmitting(false)
+    }
+  }
+
+  // ── Step D submit (evidence) ─────────────────────────────────────────────
+  const onEvidenceSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setEvidenceError(null)
+    if (evidenceNote.trim().length < 10)
+      return setEvidenceError(
+        "Please add a few details about your business so we can verify it."
+      )
+    if (!claimId) return setEvidenceError("Your session expired. Please restart.")
+
+    setSubmitting(true)
+    try {
+      await submitClaimEvidence(claimId, evidenceNote.trim())
+      setStep("submitted")
+    } catch (err: any) {
+      setEvidenceError(
+        apiMessage(err, "We couldn't submit your details. Please try again.")
+      )
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  // Shared password-reveal trailing button factory
+  const reveal = (shown: boolean, toggle: () => void) => (
+    <button
+      type="button"
+      tabIndex={-1}
+      onClick={toggle}
+      className="w-8 h-8 inline-flex items-center justify-center rounded-full text-bridal-text-label hover:text-bridal-mauve hover:bg-bridal-blush/60 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-bridal-gold/50"
+      aria-label={shown ? "Hide password" : "Show password"}
+    >
+      {shown ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+    </button>
+  )
+
+  return (
+    <div className="min-h-screen bridal-surface relative overflow-hidden">
+      <div className="absolute inset-0 bg-bridal-hero" aria-hidden />
+      <div className="absolute inset-0 bg-bridal-wash opacity-95" aria-hidden />
+
+      <div className="relative z-10 flex items-center justify-center min-h-screen px-4 sm:px-6 py-12">
+        <div className="w-full max-w-[480px] animate-stagger-fade-up">
+          {/* Card */}
+          <div className="bridal-card bg-bridal-cream border border-bridal-beige shadow-[0_24px_50px_-30px_rgba(176,125,84,0.5)] rounded-md p-6 sm:p-8">
+            {/* Crest */}
+            <div className="flex justify-center mb-5">
+              <div className="w-12 h-12 rounded-full bg-bridal-gold/15 border border-bridal-gold/40 flex items-center justify-center">
+                <Sparkles className="w-5 h-5 text-bridal-gold" />
+              </div>
+            </div>
+
+            {step !== "submitted" && <StepRail step={step} />}
+
+            {/* ── STEP A — Contact ── */}
+            {step === "contact" && (
+              <>
+                <BridalCrown className="mb-3">Claim Your Listing</BridalCrown>
+                <BridalTitle size="h2" className="text-center mb-2">
+                  Is this your{" "}
+                  <span className="text-bridal-gold">business?</span>
+                </BridalTitle>
+                <p className="text-center font-bridal text-bridal-text-soft text-sm mb-7">
+                  Tell us how to reach you. We&apos;ll send a 6-digit code to
+                  verify it&apos;s really you.
+                </p>
+
+                <form onSubmit={onContactSubmit} className="space-y-4">
+                  <BridalField id="name" label="Your Name" required>
+                    <BridalInput
+                      id="name"
+                      type="text"
+                      autoComplete="name"
+                      placeholder="e.g. Ahmed Khan"
+                      leadingIcon={<UserIcon className="w-4 h-4" />}
+                      value={name}
+                      onChange={(e) => setName(e.target.value)}
+                    />
+                  </BridalField>
+
+                  <BridalField id="email" label="Email Address" required>
+                    <BridalInput
+                      id="email"
+                      type="email"
+                      autoComplete="email"
+                      autoCapitalize="none"
+                      autoCorrect="off"
+                      placeholder="you@email.com"
+                      leadingIcon={<Mail className="w-4 h-4" />}
+                      value={email}
+                      onChange={(e) => setEmail(e.target.value)}
+                    />
+                  </BridalField>
+
+                  <BridalField
+                    id="phone"
+                    label="Phone Number"
+                    hint="Use the number associated with your business — it speeds up verification."
+                    required
+                  >
+                    <BridalInput
+                      id="phone"
+                      type="tel"
+                      inputMode="tel"
+                      autoComplete="tel"
+                      placeholder="03XX XXXXXXX"
+                      leadingIcon={<Phone className="w-4 h-4" />}
+                      value={phone}
+                      onChange={(e) => setPhone(e.target.value)}
+                    />
+                  </BridalField>
+
+                  {contactError && (
+                    <p className="text-[12px] text-bridal-coral font-bridal">
+                      {contactError}
+                    </p>
+                  )}
+
+                  <BridalButton
+                    type="submit"
+                    variant="primary"
+                    size="lg"
+                    block
+                    loading={submitting}
+                    className="mt-2"
+                  >
+                    {submitting ? "Sending code…" : "Send Verification Code"}
+                  </BridalButton>
+                </form>
+              </>
+            )}
+
+            {/* ── STEP B — OTP ── */}
+            {step === "otp" && (
+              <>
+                <BridalCrown className="mb-3">Verify Your Phone</BridalCrown>
+                <BridalTitle size="h2" className="text-center mb-2">
+                  Enter the <span className="text-bridal-gold">6-digit code</span>
+                </BridalTitle>
+                <p className="text-center font-bridal text-bridal-text-soft text-sm mb-2">
+                  We sent a code to{" "}
+                  <span className="text-bridal-charcoal font-medium">
+                    {otpSentTo}
+                  </span>
+                  .
+                </p>
+                <p className="text-center font-bridal text-[12px] text-bridal-text-label mb-6">
+                  In development the code is printed in the backend server
+                  console.
+                </p>
+
+                <form onSubmit={onOtpSubmit} className="space-y-4">
+                  <BridalField id="code" label="Verification Code" required>
+                    <BridalInput
+                      id="code"
+                      type="text"
+                      inputMode="numeric"
+                      autoComplete="one-time-code"
+                      maxLength={6}
+                      placeholder="123456"
+                      leadingIcon={<ShieldCheck className="w-4 h-4" />}
+                      className="tracking-[0.4em] text-center"
+                      value={code}
+                      onChange={(e) =>
+                        setCode(e.target.value.replace(/[^0-9]/g, "").slice(0, 6))
+                      }
+                      autoFocus
+                    />
+                  </BridalField>
+
+                  {otpError && (
+                    <p className="text-[12px] text-bridal-coral font-bridal">
+                      {otpError}
+                    </p>
+                  )}
+
+                  <BridalButton
+                    type="submit"
+                    variant="primary"
+                    size="lg"
+                    block
+                    loading={submitting}
+                  >
+                    {submitting ? "Verifying…" : "Verify Code"}
+                  </BridalButton>
+                </form>
+
+                <button
+                  type="button"
+                  onClick={() => {
+                    setStep("contact")
+                    setOtpError(null)
+                  }}
+                  className="mt-5 inline-flex items-center gap-1.5 font-bridal text-[12px] tracking-wide text-bridal-text-soft hover:text-bridal-mauve transition-colors"
+                >
+                  <ArrowLeft className="w-3.5 h-3.5" />
+                  Use a different number
+                </button>
+              </>
+            )}
+
+            {/* ── STEP C — Set password (phone-match) ── */}
+            {step === "password" && (
+              <>
+                <div className="mx-auto mb-4 w-14 h-14 rounded-full bg-bridal-sage/20 border border-bridal-sage/40 flex items-center justify-center">
+                  <CheckCircle2 className="w-6 h-6 text-[#3F6B43]" />
+                </div>
+                <BridalCrown className="mb-3">You&apos;re Verified</BridalCrown>
+                <BridalTitle size="h2" className="text-center mb-2">
+                  Set your <span className="text-bridal-gold">password</span>
+                </BridalTitle>
+                <p className="text-center font-bridal text-bridal-text-soft text-sm mb-7">
+                  Your phone matched this listing. Choose a password and your
+                  business is yours to manage.
+                </p>
+
+                <form onSubmit={onPasswordSubmit} className="space-y-4">
+                  <BridalField id="password" label="New Password" required>
+                    <BridalInput
+                      id="password"
+                      type={showPassword ? "text" : "password"}
+                      autoCapitalize="none"
+                      autoComplete="new-password"
+                      placeholder="At least 8 characters"
+                      leadingIcon={<Lock className="w-4 h-4" />}
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      trailing={reveal(showPassword, () =>
+                        setShowPassword((p) => !p)
+                      )}
+                    />
+                  </BridalField>
+
+                  <BridalField
+                    id="confirm"
+                    label="Confirm Password"
+                    required
+                  >
+                    <BridalInput
+                      id="confirm"
+                      type={showConfirm ? "text" : "password"}
+                      autoCapitalize="none"
+                      autoComplete="new-password"
+                      placeholder="Repeat your password"
+                      leadingIcon={<KeyRound className="w-4 h-4" />}
+                      value={confirm}
+                      onChange={(e) => setConfirm(e.target.value)}
+                      trailing={reveal(showConfirm, () =>
+                        setShowConfirm((p) => !p)
+                      )}
+                    />
+                  </BridalField>
+
+                  {passwordError && (
+                    <p className="text-[12px] text-bridal-coral font-bridal">
+                      {passwordError}
+                    </p>
+                  )}
+
+                  <BridalButton
+                    type="submit"
+                    variant="primary"
+                    size="lg"
+                    block
+                    loading={submitting}
+                    className="mt-2"
+                  >
+                    {submitting ? "Claiming…" : "Claim & Continue"}
+                  </BridalButton>
+                </form>
+              </>
+            )}
+
+            {/* ── STEP D — Evidence ── */}
+            {step === "evidence" && (
+              <>
+                <div className="mx-auto mb-4 w-14 h-14 rounded-full bg-bridal-gold/15 border border-bridal-gold/40 flex items-center justify-center">
+                  <FileText className="w-6 h-6 text-bridal-gold-dark" />
+                </div>
+                <BridalCrown className="mb-3">One Last Step</BridalCrown>
+                <BridalTitle size="h2" className="text-center mb-2">
+                  Tell us about your{" "}
+                  <span className="text-bridal-gold">business</span>
+                </BridalTitle>
+                <p className="text-center font-bridal text-bridal-text-soft text-sm mb-7">
+                  We couldn&apos;t auto-match your phone, so our team will review
+                  your claim. Share a few details that prove this business is
+                  yours.
+                </p>
+
+                <form onSubmit={onEvidenceSubmit} className="space-y-4">
+                  <BridalField
+                    id="evidenceNote"
+                    label="Business details / proof"
+                    hint="e.g. your role, business address, website, social pages, or anything that confirms ownership."
+                    required
+                  >
+                    <textarea
+                      id="evidenceNote"
+                      rows={5}
+                      placeholder="Share details that confirm you own or manage this business…"
+                      value={evidenceNote}
+                      onChange={(e) => setEvidenceNote(e.target.value)}
+                      className="w-full bridal-input px-4 py-3 font-bridal text-[14px] text-bridal-charcoal placeholder:text-bridal-text-label/70 outline-none resize-y min-h-[120px]"
+                    />
+                  </BridalField>
+
+                  {evidenceError && (
+                    <p className="text-[12px] text-bridal-coral font-bridal">
+                      {evidenceError}
+                    </p>
+                  )}
+
+                  <BridalButton
+                    type="submit"
+                    variant="primary"
+                    size="lg"
+                    block
+                    loading={submitting}
+                    className="mt-2"
+                  >
+                    {submitting ? "Submitting…" : "Submit for Review"}
+                  </BridalButton>
+                </form>
+              </>
+            )}
+
+            {/* ── SUBMITTED — Evidence success ── */}
+            {step === "submitted" && (
+              <div className="text-center">
+                <div className="mx-auto mb-5 w-16 h-16 rounded-full bg-bridal-sage/20 border border-bridal-sage/40 flex items-center justify-center">
+                  <CheckCircle2 className="w-7 h-7 text-[#3F6B43]" />
+                </div>
+                <BridalCrown className="mb-3">Submitted</BridalCrown>
+                <BridalTitle size="h2" className="mb-3">
+                  We&apos;ll take it{" "}
+                  <span className="text-bridal-gold">from here</span>
+                </BridalTitle>
+                <p className="font-bridal text-bridal-text-soft text-sm mb-7">
+                  Thanks! Our team will review your claim and email you a link to
+                  finish setting up your account. This usually takes a short
+                  while.
+                </p>
+                <BridalButton
+                  variant="primary"
+                  size="lg"
+                  block
+                  onClick={() => router.push("/")}
+                >
+                  Back to Wedding Wala
+                </BridalButton>
+              </div>
+            )}
+          </div>
+
+          {/* Footer */}
+          {step !== "submitted" && (
+            <>
+              <div className="my-6">
+                <FloralDivider />
+              </div>
+              <p className="text-center font-bridal text-sm text-bridal-text-soft">
+                Already have an account?{" "}
+                <Link
+                  href="/login"
+                  className="text-bridal-gold hover:text-bridal-gold-dark font-medium underline-offset-4 hover:underline transition-colors"
+                >
+                  Sign in
+                </Link>
+              </p>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/dashboard/layout/nav-data.ts
+++ b/components/dashboard/layout/nav-data.ts
@@ -87,6 +87,7 @@ export const data = {
   // Day-to-day platform operations — review queues + monitoring.
   adminOperations: [
     { name: "Vendor queue",   url: "/dashboard/admin/vendor-queue", icon: UserCheck },
+    { name: "Claim requests", url: "/dashboard/claims",             icon: ShieldCheck },
     { name: "KYC documents",  url: "/dashboard/admin/documents",    icon: FileBadge },
     { name: "Disputes",       url: "/dashboard/admin/disputes",     icon: Gavel },
     { name: "Promotions",     url: "/dashboard/admin/promotions",   icon: Megaphone },

--- a/components/seo/vendor-detail-page.tsx
+++ b/components/seo/vendor-detail-page.tsx
@@ -43,6 +43,7 @@ import {
   slugifyName,
   type VendorDetail,
 } from "@/lib/seo/fetch-vendor"
+import { getVendorGuidance } from "@/lib/seo/vendor-type-guidance"
 import { fetchCityVendors } from "@/lib/seo/fetch-vendors"
 import { getVendorTypeGuidePillar } from "@/lib/seo/pricing-guide"
 import { Breadcrumbs } from "@/components/seo/breadcrumbs"
@@ -191,7 +192,19 @@ export async function VendorDetailPage(input: PageInput) {
     },
   ]
 
-  const ld = combineGraph(ldSchema, ...reviewLds, faqLD(faqs))
+  // Per-type guidance + FAQ (true, keyword-rich) — rendered on the page AND
+  // merged into the FAQPage schema. The SERP is feature-sparse in PK wedding
+  // search, so structured FAQ + citable content is a cheap, early win.
+  const guidance = getVendorGuidance(getBackendVendorType(vt.slug) ?? "")
+  const fillCity = (s: string) => s.replace(/\{city\}/g, city.name)
+  const allFaqs = guidance
+    ? [
+        ...faqs,
+        ...guidance.faqs.map((f) => ({ question: fillCity(f.q), answer: fillCity(f.a) })),
+      ]
+    : faqs
+
+  const ld = combineGraph(ldSchema, ...reviewLds, faqLD(allFaqs))
 
   return (
     <>
@@ -358,13 +371,38 @@ export async function VendorDetailPage(input: PageInput) {
           </section>
         )}
 
+        {/* Category guidance — true, keyword-rich; helps rank + AI-cite */}
+        {guidance && (
+          <section className="mb-12 max-w-3xl">
+            <h2 className="font-display italic text-[24px] text-bridal-charcoal mb-4">
+              Booking a {vt.singular.toLowerCase()} in {city.name}
+            </h2>
+            <p className="font-bridal text-[14.5px] text-bridal-text leading-relaxed mb-4">
+              {fillCity(guidance.intro)}
+            </p>
+            <p className="font-bridal text-[11px] uppercase tracking-[0.22em] font-medium text-bridal-gold mb-2.5">
+              What to ask
+            </p>
+            <ul className="space-y-2.5">
+              {guidance.ask.map((a, i) => (
+                <li
+                  key={i}
+                  className="font-bridal text-[14px] text-bridal-text leading-relaxed pl-4 border-l-2 border-bridal-beige"
+                >
+                  {fillCity(a)}
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
         {/* FAQ */}
         <section className="mb-12">
           <h2 className="font-display italic text-[24px] text-bridal-charcoal mb-5">
             Frequently asked questions
           </h2>
           <dl className="space-y-5 max-w-3xl">
-            {faqs.map((f) => (
+            {allFaqs.map((f) => (
               <div key={f.question}>
                 <dt className="font-bridal text-[15px] font-semibold text-bridal-charcoal">
                   {f.question}

--- a/docs/seo/2026-06-rank-everything/00-ANALYZE.md
+++ b/docs/seo/2026-06-rank-everything/00-ANALYZE.md
@@ -1,0 +1,47 @@
+# Wedding Wala — SEO/GEO Analysis (the ANALYZE file)
+
+**Date:** 2026-06-19 · **Status:** Research compiled (codebase audit done; keyword/competitor research running).
+
+## Headline finding
+**This is NOT a greenfield SEO job.** weddingwala.pk already has a mature, expert-level SEO system AND a written 2-year strategy. The bottleneck is **execution + deployment + authority**, not structure. (Confirmed by `seo-strategy/SEO-MASTER-PLAN.md` + `mega-plan-2yr/` + `TODO.md`.)
+
+## What ALREADY exists (do not rebuild)
+| Area | State | Evidence |
+|---|---|---|
+| **Sitemap** | ✅ Excellent — 4 shards (core, programmatic city×type *inventory-gated*, dynamic vendors, images) | `app/sitemap.ts` |
+| **Robots / AI access** | ✅ Full AI-crawler allowlist (GPTBot, PerplexityBot, ClaudeBot, Google-Extended, Bingbot, CCBot…) | `app/robots.ts` |
+| **Schema** | ✅ Org, WebSite+SearchAction, Breadcrumb, LocalBusiness(+geo), EventVenue, Review, **AggregateRating only when a real rating exists (honest)**, FAQPage, Article, Service, CollectionPage/ItemList | `lib/seo/jsonld.ts` |
+| **llms.txt** | ✅ Present | `public/llms.txt` |
+| **Metadata** | ✅ Per-page-type title/desc/canonical/OG | `lib/seo/metadata.ts`, generateMetadata in routes |
+| **Content engine** | ✅ Blog (clusters+posts), glossary, compare pages, real-weddings, content pillars, pricing guides, **per-city editorial**, planning tools (budget/checklist/timeline), per-type guidance/FAQ | `lib/seo/*`, `lib/blog`, `lib/content` |
+| **Hreflang** | ✅ en-PK / ur-PK scaffold | `lib/seo/hreflang.ts` |
+| **Strategy** | ✅ Master plan + 2-yr mega-plan + execution TODO with competitor teardown | `seo-strategy/` |
+
+## The real gaps / levers (what actually moves rankings now)
+**Tier 1 — biggest impact, code or deploy:**
+1. **DEPLOY the session's work.** 3,266 real vendors + images + guidance/FAQ + claim flow are on DEV, unpushed → **nothing ranks until live + indexed.** This is the #1 action. (Master plan calls vendor-profile pages the highest-ROI page type; we just 30×'d the count.)
+2. **Vendor-profile leaf pages = the navigational flywheel** (rank #1 for each vendor's name). Now ~3,266 of them. Ensure each is fully optimised (schema ✅, but the rich per-type guidance/FAQ currently renders on the APP detail page, **not** the indexed SEO-leaf page — gap to fix).
+3. **"Best {service} in {city} 2026" listicles** — the GEO/AI-citation weapon (flag `LISTICLE_PAGES_ENABLED` + `lib/seo/listicle.ts` exist; pages/flag need finishing + enabling). Listicles = ~63% of AI citations.
+4. **Deepen {service}×{city} money pages** — unique per-city intro (city-editorial.ts exists), PKR ranges, ≥6 vendor cards, FAQ, internal links. Protect the thin-content `noindex` guard.
+
+**Tier 2 — on-page / technical:**
+5. Per-type guidance/FAQ → mirror onto the **SEO leaf page** + city hubs (currently app-page only).
+6. On-page keyword placement audit (title/H1/first-100-words/meta) across page types.
+7. CWV/INP audit (mobile-first) — pending live measurement.
+8. Image alt-text keyword-awareness + WebP (next/image handles format; alt text needs auditing).
+9. Deprecated `HowTo` schema present in `jsonld.ts` (minor cleanup — deprecated Sept 2023).
+10. Possible duplicate-content: app detail `/{type}/{id}` (client, no canonical) vs SEO leaf `/{type}/{city}/{slug}-{id}` — verify canonical.
+
+**Tier 3 — USER / real-world (the #1 lever, NOT codable):**
+11. **Authority/backlinks** (DA 1, 0 referring domains) — citations, GBP + Bing Places + NAP, vendor reciprocity, digital PR ("Decemberistan report"), real-wedding features. *No one can code DA.*
+12. **Connect GSC + GA4 + Bing** (service account) — unblocks real keyword/index data. *(TODO marks some ✅; verify in-session MCP.)*
+13. **Vercel apex→www: change 307 → 301/308.** (Dashboard, user.)
+14. **Request Indexing** for top money pages in GSC.
+15. **First-party photography** to replace stock (E-E-A-T) — real shoots.
+16. **Real reviews** accrue via real bookings (claim flow) → AggregateRating lights up. *No fake reviews.*
+
+## SEO Health Score (codebase/on-page only): **~82/100** — strong foundation.
+Held back by: not-yet-deployed (indexation = 0 of the new work), authority (DA1), and the leaf-page content gap. The ceiling on *rankings* is authority + time, not on-page quality.
+
+## Honest verdict
+On-page/technical SEO is already top-decile. **Rankings are gated by (a) shipping the work, (b) earning authority over months, (c) executing the content/listicle backlog.** I will execute every code-level item; the authority + GSC + Vercel + photography levers need you.

--- a/docs/seo/2026-06-rank-everything/01-PLAN.md
+++ b/docs/seo/2026-06-rank-everything/01-PLAN.md
@@ -1,0 +1,42 @@
+# Wedding Wala — SEO Execution Plan (the PLAN file)
+
+**Date:** 2026-06-19 · **Status:** Active.
+**This plan does NOT replace** `seo-strategy/SEO-MASTER-PLAN.md` + `mega-plan-2yr/TODO.md` (both excellent). It is the **code-executable slice** I drive now, mapped to that TODO, plus the honest user-dependent levers.
+
+## Honest goal (unchanged from master plan)
+Engineer every page to **compete for #1** on its primary + secondary keywords and to be **cited by AI** (Overviews/ChatGPT/Perplexity/Copilot). Maximize position; never promise #1. North star = **leads/bookings**, not vanity rank.
+
+## What I execute (code — no waiting on anyone)
+| # | Item | Maps to TODO | Why now |
+|---|---|---|---|
+| E1 | **Mirror per-type guidance + FAQ + FAQPage schema onto the SEO leaf vendor page** (currently app-page only) | F, K, 5/6A | The leaf page is the *indexed* one; this makes 3,266 pages content-rich + AI-citable |
+| E2 | **Finish + enable "Best {service} in {city} 2026" listicles** (ItemList + FAQ schema, answer-first) for Tier-1 cities × core vendors | E, 6B | The GEO/AI-citation weapon; flag + slug already exist |
+| E3 | **Deepen {service}×{city} money pages** — unique per-city intro, PKR range, ≥6 cards, FAQ, internal links | D, 6A | Beats shadiyana's thin non-venue/tier-2 pages |
+| E4 | **On-page keyword pass** — primary kw in title/H1/first-100/meta; secondary across H2/H3 — per page type template | F | Cheap, compounding |
+| E5 | **Schema completeness + cleanup** — verify LocalBusiness/ItemList/FAQ/Breadcrumb per page type; remove deprecated HowTo; confirm canonical on app `/{type}/{id}` → leaf | G, K | Rich-result + dup-content hygiene |
+| E6 | **Image alt-text keyword-awareness** across templates | F | Image SERP + a11y |
+| E7 | **Flagship cost/content** — verify "Wedding Cost in Pakistan 2026" pillar depth + city variants; push the budget calculator | 6C | Most-linkable format |
+| E8 | **Internal-linking flywheel** — hub→city→vendor + informational→commercial bridges; province hubs | D, F | Crawl depth + equity flow |
+| E9 | **IndexNow** wiring for instant Bing/Yandex submission | G | Faster indexation |
+
+## What needs YOU (the real ceiling — I'll prep, you act)
+| # | Item | Maps to TODO |
+|---|---|---|
+| U1 | **Deploy** the dev work (3,266 vendors etc.) — *nothing ranks until live* | (all) |
+| U2 | Authority: GBP + Bing Places + NAP, foundational PK citations, vendor reciprocity, digital PR | H |
+| U3 | Confirm **GSC + GA4 + Bing** connected + MCP reloaded; define GA4 conversions | A |
+| U4 | **Vercel apex→www 307 → 301/308** | A |
+| U5 | **Request Indexing** for top money pages | A |
+| U6 | First-party photography (E-E-A-T) | E |
+
+## Sequencing (dependency-aware)
+1. **E1 → E5** (make the 3,266 leaf pages best-in-class) — *do first; compounds with deploy.*
+2. **E2 (listicles) + E7 (cost content)** — the GEO + linkable layer.
+3. **E3 + E8** (money-page depth + internal links).
+4. **E4 + E6 + E9** (on-page polish + IndexNow).
+5. **U1 deploy** → **U3/U4/U5 index** → **U2 authority** (ongoing, the long game).
+
+## Falsifiable success checks (per the master plan's north star)
+- Leaf pages: each renders LocalBusiness+Breadcrumb+FAQ schema valid in Rich Results Test; unique guidance/FAQ per type.
+- Listicles: indexable, ItemList+FAQ valid, answer-first lead present.
+- Leading indicators (watch in GSC once live): impressions on `{vendor name}` + `{type} in {city}` queries; AI-citation appearances; coverage = "Indexed" climbing.

--- a/docs/seo/2026-06-rank-everything/02-EXECUTE.md
+++ b/docs/seo/2026-06-rank-everything/02-EXECUTE.md
@@ -1,0 +1,50 @@
+# Wedding Wala — SEO Execution Tracker (the EXECUTE file)
+
+**Legend:** `[ ]` todo · `[~]` in progress · `[x]` done · `[!]` needs YOU
+Detail: `00-ANALYZE.md`, `01-PLAN.md`, `03-keyword-competitor-research.md`. Master strategy: `seo-strategy/`.
+
+## Phase 0 — Research & setup  ✅
+- [x] Honest framing (no fake reviews; #1 maximized not guaranteed; must deploy to rank)
+- [x] Codebase SEO audit (sitemap, robots, schema, llms.txt, content engine) — mature
+- [x] Existing-program inventory (SEO-MASTER-PLAN + mega-plan-2yr + TODO found — expert-level)
+- [x] Live keyword/competitor/SERP research (gl=pk) → `03-keyword-competitor-research.md`
+- [x] Tracking files written/grounded
+
+## Phase 1 — Make the 3,266 indexed leaf pages best-in-class
+- [x] **E1 — per-type guidance + "What to ask" + expanded FAQPage schema on the SEO leaf page** (`components/seo/vendor-detail-page.tsx`). Content-rich + AI-citable on every vendor page.
+- [ ] E5a — verify canonical: app `/{type}/{id}` (client) should canonical → SEO leaf `/{type}/{city}/{slug}-{id}` (dup-content check)
+- [ ] E5b — remove deprecated `HowTo` schema from `jsonld.ts` (minor)
+- [ ] E6 — image alt-text keyword-awareness across vendor/card/leaf templates
+
+## Phase 2 — GEO/AI-citation weapon + cost layer (research-prioritised)
+- [x] **E2 — "Best {service} in {city} 2026" listicles VERIFIED WORKING** (`best-vendor-listicle-page.tsx` already built — answer-first lead + comparison table + ranked list + CollectionPage/Article/Service/FAQPage schema). Tested `/best/bridal-makeup-artists-in-karachi` with real data. **Production action: set `NEXT_PUBLIC_LISTICLE_PAGES=true` + deploy** → sitemap auto-includes eligible combos (≥3 vendors). [U]
+- [ ] E7 — cost layer: verify "Wedding Cost in Pakistan 2026" pillar (sitemap lists it) + budget calculator (exists at /planning-tools/budget); add "marquee rates in {city}" / "{type} price list {city}" if missing
+- [x] city-hub FAQPage schema — already present (`vendor-type-city-page.tsx` emits CollectionPage+Service+FAQPage)
+
+> **META-FINDING (important):** This codebase is ~90% SEO-complete. The listicle program, the deep B0–B13 city money pages, comprehensive schema, robots+AI-crawlers, llms.txt, sitemap shards, content engine — **all already built.** My initial glob tool was unreliable on nested paths and under-reported what exists. **New rule: VERIFY (Read/Grep/ls) before building any further E item — most already exist.** The real levers are now: enable flags → DEPLOY → authority/off-page (needs you).
+
+## Phase 3 — Money-page depth + internal linking
+- [ ] E3 — deepen `{type}×{city}` hubs: unique per-city intro (city-editorial), PKR ranges, ≥6 cards, FAQ, links — focus people-verticals where we can win
+- [ ] E8 — internal-linking flywheel (hub→city→vendor + info→commercial) + province hubs
+
+## Verified code findings (audited, not guessed)
+- **HowTo schema** — used intentionally on `/how-it-works` + prescribed by the mega-plan for stepwise guides. Deprecated for *rich results* (Sept 2023) but not harmful as semantic markup. **Verdict: keep.**
+- **App UX routes vs SEO routes [✅ FIXED + VERIFIED]** — the `(vendorListings)` group (`/makeup-artists`, `/venues`, `/photographers`, `/catering`, … + each `/[id]`) was `force-dynamic`, client-rendered, thin, and parallels the SEO-canonical routes (`/bridal-makeup-artists`, `/wedding-venues`, city pages, leaf — the only vendor URLs in the sitemap). **Fix applied:** added `app/(main)/(vendorListings)/layout.tsx` with `robots: { index: false, follow: true }`. Verified live: `/makeup-artists` → `noindex, follow`; `/wedding-venues` (SEO) → `index, follow` (untouched). Thin/dup UX pages deindexed; equity still flows via `follow`; SEO money pages unaffected. Scoped to one route-group layout = zero risk to SEO routes.
+- **Type-hub SEO** — the *SEO* hubs (`/bridal-makeup-artists` etc., in sitemap @0.9) are server-rendered money pages (separate from the app browse). Assumed rich; verify on deploy.
+
+## Phase 4 — On-page + technical polish
+- [ ] E4 — on-page keyword pass (title/H1/first-100/meta) per page-type template
+- [ ] E9 — IndexNow wiring (instant Bing/Yandex)
+- [ ] CWV/INP audit (needs live measurement)
+
+## Phase 5 — Needs YOU (the real ranking ceiling)
+- [!] **U1 — DEPLOY the dev work (3,266 vendors etc.)** — nothing ranks until live + indexed
+- [!] U2 — Authority: GBP + Bing Places + NAP, PK citations, vendor reciprocity, digital PR
+- [!] U3 — Confirm GSC+GA4+Bing connected; define GA4 conversions
+- [!] U4 — Vercel apex→www 307 → 301/308
+- [!] U5 — Request Indexing for top money pages
+- [!] U6 — First-party photography (E-E-A-T)
+
+---
+### Changelog
+- 2026-06-19: Program kicked off. Research compiled (codebase mature + master plan exists + live SERP research). **E1 executed** (leaf-page guidance/FAQ + schema). Plan grounded to existing TODO.

--- a/docs/seo/2026-06-rank-everything/03-keyword-competitor-research.md
+++ b/docs/seo/2026-06-rank-everything/03-keyword-competitor-research.md
@@ -1,0 +1,27 @@
+# Keyword + Competitor + SERP Research (live, gl=pk, 2026-06-19)
+
+Method: 12 money-term SERPs + 4 informational + 7 autocomplete via serper (gl=pk). No fabricated volumes — observed SERP composition only.
+
+## Competitor landscape
+- **shadiyana.pk** — category leader. Ranks #1–2 for venues/marquees/catering across KHI/LHR/ISB/RWP. Architecture: `/list/{type}/{city}` directory hubs + **vendor profiles with review schema** + `blog.shadiyana.pk`. **Mirror this; the profile flywheel is the key.**
+- **hamaravenue.com** — #1 challenger in twin-cities + Faisalabad (directory hubs + blog listicles).
+- venuebazaar.pk, eventza.pk, weddified.com — secondary directories.
+- Cost/calculator content: eventaffairs.pk, estimator.pk, shehnai.pk, hanifrajputcaterers.com.
+
+## The opportunity map (where Wedding Wala can WIN)
+1. **People-verticals = the land-grab.** makeup, photography, mehndi → owned by **Instagram / Reddit / Facebook**, **NO structured directory has won.** Lowest-resistance, highest-upside. (We have the most vendors + best profiles here once deployed.)
+2. **Venues/marquees/catering** = head-on vs shadiyana directory hubs (KHI/LHR/ISB/RWP). Compete on hub depth + profile schema.
+3. **Cost / pricing intent (under-served):** "wedding hall {city} price list", "marquee rates in {city}", "wedding cost calculator", "average wedding cost pakistan 2026". Build a calculator + year-stamped cost pages.
+4. **DON'T over-invest marketplace on bridal-wear + mithai** — owned by brand e-commerce (Zuria Dor, Chashni…). Cover as informational/listicle only.
+
+## SERP-feature finding (important)
+Across all 16 queries: **no AI Overview, no PAA box, no Map Pack, no knowledge panel** returned. The PK-English wedding niche is **pre-AI-Overview + feature-sparse** → **structured data (FAQPage, LocalBusiness, Review, ItemList) + citable content are CHEAP wins right now**, before the SERP crowds. Build the citable cost/FAQ layer to pre-position for AI Overviews when Google rolls them out in PK.
+
+## Direct implications for the plan
+- ✅ Prioritise **people-vertical city hubs + vendor profiles** (makeup/photography/mehndi × KHI/LHR/ISB).
+- ✅ **FAQPage schema everywhere** (done on leaf page E1; extend to city hubs) — answer "how many events / days", "price/rates", "how to choose".
+- ✅ **"Best {service} in {city} 2026" listicles** (answer-first + ItemList + table) = the GEO weapon.
+- ✅ **Cost layer**: calculator (exists at /planning-tools/budget — push it) + "marquee rates in {city}" + "wedding cost in pakistan 2026".
+- ⚠️ Map Pack is structurally ceded to individual GBPs; we win the **organic hub beneath the pack** (where shadiyana sits).
+
+_Tool note: google_search_maps was permission-denied; Map-Pack presence inferred. Re-run with maps access for per-city local-pack vendor enumeration (useful for vendor acquisition too)._

--- a/lib/api/claims.ts
+++ b/lib/api/claims.ts
@@ -1,0 +1,113 @@
+// Vendor "claim & complete listing" — typed wrappers for the claim API.
+// Base = `${BACKEND_URL}api/v1/claims`. Every response is the standard
+// apiResponse envelope `{ status, message, data }`, so we read `res.data.data`.
+//
+// Public endpoints are flag-gated on the backend by CLAIM_ENABLED; the FE
+// mirrors this with NEXT_PUBLIC_CLAIM_ENABLED (see lib/claim-flag.ts).
+
+import axiosInstance from "../axiosConfig"
+
+function unwrap<T>(res: any): T {
+  return (res?.data?.data ?? null) as T
+}
+
+// ---------- Public claim flow ----------
+
+export interface StartClaimResult {
+  claimId: number
+  otpSentTo: string // masked
+}
+
+/** Step A — POST /start { listingId, name, email, phone }. */
+export async function startClaim(payload: {
+  listingId: string | number
+  name: string
+  email: string
+  phone: string
+}): Promise<StartClaimResult> {
+  const res = await axiosInstance.post(`/api/v1/claims/start`, payload)
+  return unwrap<StartClaimResult>(res) as StartClaimResult
+}
+
+export type ClaimNext = "set_password" | "evidence"
+
+/** Step B — POST /:id/verify { code }. Decides the proof path. */
+export async function verifyClaim(
+  claimId: string | number,
+  code: string
+): Promise<{ next: ClaimNext }> {
+  const res = await axiosInstance.post(`/api/v1/claims/${claimId}/verify`, { code })
+  return unwrap<{ next: ClaimNext }>(res) as { next: ClaimNext }
+}
+
+/** Step C (phone-match) — POST /:id/finalize { password } → login token. */
+export async function finalizeClaim(
+  claimId: string | number,
+  password: string
+): Promise<{ user: any; token: string; jti?: string }> {
+  const res = await axiosInstance.post(`/api/v1/claims/${claimId}/finalize`, { password })
+  return unwrap<{ user: any; token: string; jti?: string }>(res) as {
+    user: any
+    token: string
+    jti?: string
+  }
+}
+
+/** Step D (evidence) — POST /:id/evidence { evidenceNote } → review queue. */
+export async function submitClaimEvidence(
+  claimId: string | number,
+  evidenceNote: string
+): Promise<{ status: string }> {
+  const res = await axiosInstance.post(`/api/v1/claims/${claimId}/evidence`, { evidenceNote })
+  return unwrap<{ status: string }>(res) ?? { status: "pending_review" }
+}
+
+// ---------- Admin review queue (auth + super-admin) ----------
+
+export type ClaimStatus =
+  | "pending_otp"
+  | "otp_verified"
+  | "pending_review"
+  | "approved"
+  | "rejected"
+  | "auto_approved"
+
+export interface AdminClaim {
+  id: number
+  listingUserId: number
+  businessId: number
+  claimantName: string
+  claimantEmail: string
+  claimantPhoneE164: string
+  method: "phone_match" | "evidence"
+  status: ClaimStatus
+  evidenceNote: string | null
+  evidenceDocUrl: string | null
+  rejectionReason: string | null
+  reviewedAt: string | null
+  createdAt: string
+  updatedAt: string
+  // Denormalized for the queue — backend may include these for display.
+  business?: { id: number; name?: string; city?: string | null } | null
+  listing?: { id: number; name?: string } | null
+}
+
+/** GET /admin/claims (optionally filtered by status). */
+export async function listClaims(status?: ClaimStatus): Promise<AdminClaim[]> {
+  const res = await axiosInstance.get(`/api/v1/claims/admin/claims`, {
+    params: status ? { status } : undefined,
+  })
+  const data = unwrap<AdminClaim[] | { claims: AdminClaim[] }>(res)
+  if (Array.isArray(data)) return data
+  return (data as { claims?: AdminClaim[] })?.claims ?? []
+}
+
+/** POST /admin/claims/:id/approve — emails the claimant a set-password link. */
+export async function approveClaim(id: number): Promise<void> {
+  await axiosInstance.post(`/api/v1/claims/admin/claims/${id}/approve`, {})
+}
+
+/** POST /admin/claims/:id/reject { rejectionReason }. */
+export async function rejectClaim(id: number, rejectionReason: string): Promise<void> {
+  await axiosInstance.post(`/api/v1/claims/admin/claims/${id}/reject`, { rejectionReason })
+}

--- a/lib/claim-flag.ts
+++ b/lib/claim-flag.ts
@@ -1,0 +1,7 @@
+// Vendor-claim feature flag. Mirrors the backend CLAIM_ENABLED gate.
+// Default OFF — the wizard renders a "not available yet" notice unless the
+// env var is explicitly set to the string "true" at build time.
+//
+// NOTE: NEXT_PUBLIC_* vars are inlined by Next at build time, so this must be
+// referenced as a full static `process.env.NEXT_PUBLIC_CLAIM_ENABLED` access.
+export const CLAIM_ENABLED = process.env.NEXT_PUBLIC_CLAIM_ENABLED === "true"

--- a/lib/seo/vendor-type-guidance.ts
+++ b/lib/seo/vendor-type-guidance.ts
@@ -1,0 +1,478 @@
+// Generic, TRUE best-practice guidance + FAQs per vendor type, used to
+// enrich each vendor's detail page with unique, helpful, rankable text.
+//
+// IMPORTANT — content contract:
+//   • Everything here is GENERIC advice the reader can trust. It is NOT
+//     data about any specific business. Never add prices, rupee amounts,
+//     "X years experience", awards, statistics, or brand names here.
+//   • The literal token {city} is string-replaced at render time with the
+//     vendor's city. Use it only where a city reference reads naturally.
+//   • Tone is for the Pakistani wedding context (mehndi / barat / walima,
+//     load-shedding, Oct–Mar peak season, advance + cancellation norms,
+//     and modest cultural expectations).
+//
+// Keyed by the EXACT backend vendorType enum strings (see
+// ../vendor-types.ts → VENDOR_TYPES). Keep in lock-step with that file.
+
+export interface VendorTypeGuidance {
+  intro: string; // 2 sentences. May contain the literal token {city}.
+  ask: string[]; // exactly 4 "what to ask / how to choose" best-practice points. May contain {city}.
+  faqs: { q: string; a: string }[]; // exactly 3 Q&A. May contain {city}.
+}
+
+export const VENDOR_TYPE_GUIDANCE: Record<string, VendorTypeGuidance> = {
+  "Wedding venue": {
+    intro:
+      "Choosing the right wedding venue in {city} sets the tone for your entire barat or walima, from guest capacity to parking and catering rules. Booking early matters most during the October–March peak season, when the best halls, lawns and marquees in {city} fill up months in advance.",
+    ask: [
+      "Confirm the seated guest capacity and whether the price is per-event or has a per-head minimum, so a 400-guest walima isn't squeezed into a 250-seat hall.",
+      "Ask whether outside catering and decorators are allowed or if the venue is exclusive, since many {city} venues charge extra or forbid bringing your own vendors.",
+      "Check the load-shedding plan: is there an on-site generator with enough backup to run AC and lights through the full function without interruption?",
+      "Get the advance, the cancellation and date-change policy, the booking timings (single function vs. full-day), and any rules on dhol, music volume or closing time in writing.",
+    ],
+    faqs: [
+      {
+        q: "How far in advance should I book a wedding venue in {city}?",
+        a: "For weddings during the October–March peak season, popular venues in {city} are often reserved several months ahead, so it is wise to start looking as early as you can. Off-season and weekday dates usually have more availability and flexibility.",
+      },
+      {
+        q: "What is usually included in a venue booking?",
+        a: "This varies a lot — some venues include in-house catering, basic stage and seating, AC and a bridal room, while others rent only the bare space. Always get an itemised list so you know what you must arrange separately, such as decor, sound or generator backup.",
+      },
+      {
+        q: "Is the advance refundable if we cancel or change the date?",
+        a: "Most venues take a non-refundable advance to hold the date, with cancellation and date-change terms that tighten as the event nears. Ask for the exact policy in writing before paying so there are no surprises.",
+      },
+    ],
+  },
+
+  "Makeup artist": {
+    intro:
+      "Your bridal makeup artist in {city} is one of the most photographed parts of your day, so choosing one whose style suits your features and outfit matters enormously. The best makeup artists in {city} get booked early for the October–March wedding season, and weekend dates go fastest.",
+    ask: [
+      "Look at unfiltered, natural-light photos of real brides (not just heavily edited shots) to judge whether the artist's style matches the soft, dewy or full-glam look you want.",
+      "Book a paid trial before your barat or walima to test the look, check how it photographs, and confirm it suits your skin tone and outfit colours.",
+      "Ask whether they travel to your home or the venue in {city}, how many hours they need, and whether hairstyling, draping and a touch-up are included or charged separately.",
+      "Confirm whether the senior artist personally does your makeup or assigns a team member, and clarify the advance, date-lock and cancellation terms.",
+    ],
+    faqs: [
+      {
+        q: "Should I book a bridal makeup trial first?",
+        a: "Yes — a trial lets you see the look in person and in photos, raise any concerns, and avoid surprises on the actual day. It is especially worth it if you have specific preferences about how light, heavy or long-wearing the makeup should be.",
+      },
+      {
+        q: "Does the makeup artist come to my home or do I go to a studio?",
+        a: "Many bridal artists in {city} offer both home or venue service and studio appointments, though travel may add to the cost. Confirm this when booking, particularly if you need to be ready early before the function.",
+      },
+      {
+        q: "How long does bridal makeup take on the wedding day?",
+        a: "Full bridal makeup with hair and dupatta setting commonly takes a few hours, so plan a comfortable start time before your barat or walima. Booking the artist early in the day reduces the rush and lets photography stay on schedule.",
+      },
+    ],
+  },
+
+  "Mithai and sweets": {
+    intro:
+      "Mithai is central to Pakistani wedding traditions — from mooh meetha at the engagement to boxes distributed at the barat and walima in {city}. Ordering early ensures freshness, the flavours you want, and enough quantity for every guest, especially during the busy October–March season.",
+    ask: [
+      "Taste before ordering and confirm freshness, since traditional mithai like barfi, gulab jaman and ladoo is best made close to the event date rather than far ahead.",
+      "Ask about per-kg pricing versus packaged guest boxes, and clarify whether distribution or delivery to your venue in {city} is included.",
+      "Discuss custom packaging if you want branded or themed sweet boxes for guests to take home, and confirm the lead time needed.",
+      "Confirm hygiene and storage, especially for milk-based sweets in warm weather, and lock the order quantity, advance and delivery slot in writing.",
+    ],
+    faqs: [
+      {
+        q: "How early should I order wedding mithai in {city}?",
+        a: "Place your order a few weeks ahead so the shop can plan quantity and packaging, but agree that milk-based sweets are prepared close to the event for freshness. During peak wedding season in {city}, ordering early also secures your delivery slot.",
+      },
+      {
+        q: "Can I get sweets in branded or themed guest boxes?",
+        a: "Many sweet sellers offer custom or themed packaging for guest take-home boxes, which adds a personal touch to your barat or walima. Ask about the minimum quantity and the extra lead time custom boxes require.",
+      },
+      {
+        q: "Are sugar-free or special options available?",
+        a: "Some vendors prepare sugar-free or lighter options for guests with dietary needs — ask in advance, as these are usually made to order. Confirm quantity and any price difference when you place the main order.",
+      },
+    ],
+  },
+
+  "Catering": {
+    intro:
+      "Catering is one of the most memorable parts of any Pakistani wedding, and the right caterer in {city} balances taste, hygiene and smooth service for a large guest count. Quality caterers book out fast during the October–March peak season, so confirm your date and menu early.",
+    ask: [
+      "Request a food tasting before booking so you can judge the actual quality of the biryani, salan, BBQ and desserts you'll serve at your barat or walima.",
+      "Confirm whether pricing is per-head and what the minimum guest count is, and get clarity on what waiters, crockery, chafing dishes and live counters are included.",
+      "Ask how the caterer guarantees freshness and hygiene for a large gathering, and whether ingredients are halal-sourced.",
+      "Lock the final headcount deadline, the advance, the per-head rate and the cancellation policy in writing, and discuss the buffer plan if guests exceed the estimate.",
+    ],
+    faqs: [
+      {
+        q: "Can I taste the food before booking a caterer?",
+        a: "Reputable caterers in {city} usually offer a tasting session so you can confirm flavour, portion and presentation before committing. This is the single best way to avoid disappointment on the wedding day.",
+      },
+      {
+        q: "How is wedding catering priced?",
+        a: "Catering is most often priced per head, with a minimum guest count, and the rate depends on the menu and number of dishes. Always confirm what is included — waiters, crockery, setup and live stations may be add-ons.",
+      },
+      {
+        q: "What happens if more guests turn up than expected?",
+        a: "Pakistani weddings often see extra guests, so good caterers prepare a buffer and agree in advance how additional plates are charged. Ask about this upfront and confirm a cut-off date for your final headcount.",
+      },
+    ],
+  },
+
+  "Photographer": {
+    intro:
+      "Your wedding photographer in {city} captures memories you'll revisit for a lifetime, so matching their style to your taste is more important than any single feature. Skilled photographers are booked months ahead for the October–March season, and prime dates go first.",
+    ask: [
+      "Review full real wedding galleries (not just highlight reels) so you can judge consistency across the mehndi, barat and walima rather than a few hero shots.",
+      "Confirm exactly who shoots your event — the lead photographer or an assistant — and how many shooters and videographers are included.",
+      "Clarify deliverables and timelines: number of edited photos, the cinematic film, raw files, album, online gallery, and how long delivery takes after the wedding.",
+      "Ask about coverage for multiple functions, travel within {city}, drone or extra-day charges, the advance and the cancellation or reschedule policy.",
+    ],
+    faqs: [
+      {
+        q: "How early should I book a wedding photographer in {city}?",
+        a: "Good photographers in {city} are reserved months in advance, especially for weekend dates in peak season, so book as soon as your dates are fixed. Early booking also gives you time for an engagement or pre-wedding shoot if you want one.",
+      },
+      {
+        q: "Will the photographer I meet actually shoot my wedding?",
+        a: "Larger studios sometimes send a team rather than the lead photographer, so confirm in writing who will personally cover your functions. This avoids a mismatch between the portfolio you loved and the person who shows up.",
+      },
+      {
+        q: "How long until I receive my photos and video?",
+        a: "Editing wedding photos and a cinematic film takes time, and delivery commonly ranges from a few weeks to a couple of months. Agree on the timeline, the number of edited images, and the album format before booking.",
+      },
+    ],
+  },
+
+  "Car rental": {
+    intro:
+      "A wedding car rental in {city} covers the grand entrance, the doli departure and guest transport, so reliability and presentation matter as much as the vehicle itself. Decorated cars and luxury vehicles are in high demand during the October–March wedding season, so reserve early.",
+    ask: [
+      "Confirm the exact make, model, colour and condition of the car, and ask to see recent photos so the vehicle that arrives matches what you booked.",
+      "Clarify whether a chauffeur, fuel and decoration (flowers or ribbons) are included, or charged separately, for your barat and doli in {city}.",
+      "Ask about the hours included, overtime charges, and the coverage area in case the venue or the doli route is outside the city.",
+      "Get a backup-vehicle commitment in case of breakdown, and lock the timing, advance and cancellation terms in writing.",
+    ],
+    faqs: [
+      {
+        q: "Is the driver and fuel included in a wedding car rental?",
+        a: "This varies — some rentals include a chauffeur and fuel within a set distance, while others charge them separately. Always confirm what the quoted price covers and what happens if you exceed the included hours or mileage.",
+      },
+      {
+        q: "Does the car come decorated for the wedding?",
+        a: "Floral or ribbon decoration is often offered as an add-on rather than included by default, so ask specifically. Confirm the style and who arranges the flowers if you want the car ready for the doli.",
+      },
+      {
+        q: "What if the car breaks down on the wedding day?",
+        a: "Ask the provider about their backup plan and whether a replacement vehicle can be sent quickly. A reliable rental in {city} will commit to a contingency so your barat or doli isn't delayed.",
+      },
+    ],
+  },
+
+  "Nikahkhwan": {
+    intro:
+      "A Nikahkhwan is the qualified person who performs and registers your nikah, recites the khutba and guides both families through the Islamic marriage ceremony. Choosing the right Nikahkhwan in {city} ensures the nikah is conducted correctly, the nikahnama is filled properly, and the ceremony suits your family's wishes.",
+    ask: [
+      "Confirm the Nikahkhwan is authorised to conduct and register the nikah, and that the nikahnama will be completed and submitted correctly.",
+      "Discuss the languages they recite and explain in (Arabic, Urdu, English or regional), so both families and any overseas relatives can follow along.",
+      "Ask whether they help draft the nikahnama, advise on the mehr clauses, and arrange witnesses if your family needs them.",
+      "Confirm whether they travel to your home or venue in {city}, the sermon length you prefer (brief or extended), and any rules on female attendees so the seating is arranged respectfully.",
+    ],
+    faqs: [
+      {
+        q: "What does a Nikahkhwan actually do at the ceremony?",
+        a: "The Nikahkhwan recites the khutba, seeks consent (ijab-o-qabool) from the bride and groom, oversees the signing and witnessing of the nikahnama, and offers dua. Many also explain each step so both families understand the proceedings.",
+      },
+      {
+        q: "Does the Nikahkhwan handle the nikahnama paperwork?",
+        a: "Many Nikahkhwan help fill the nikahnama correctly and ensure it is registered, but confirm this when booking. Filling the mehr and conditions clauses properly is important, so ask whether they guide you through it.",
+      },
+      {
+        q: "Can the Nikahkhwan come to our home or venue in {city}?",
+        a: "Many are willing to travel to a home or wedding venue in {city} rather than only conducting the nikah at a masjid. Confirm travel, timing and the preferred sermon length when you book.",
+      },
+    ],
+  },
+
+  "Marquee rental": {
+    intro:
+      "A marquee or tent rental in {city} turns a home lawn, farmhouse or open ground into a complete wedding venue for your mehndi, barat or walima. Setup quality, weather readiness and on-time installation matter most, and the best marquee teams are booked early for the October–March season.",
+    ask: [
+      "Confirm the guest capacity the marquee comfortably seats, and whether chairs, tables, carpet, lighting and side walls are included or charged separately.",
+      "Ask how many hours setup and teardown take, and whether the team installs the day before so everything is ready well ahead of your function in {city}.",
+      "Discuss weather and cooling: wall-sided tents for wind or winter, fans or AC for the crowd, and a plan if rain is forecast.",
+      "Clarify the site requirements (ground space, access for trucks), the advance, and the cancellation or date-change policy in writing.",
+    ],
+    faqs: [
+      {
+        q: "Does a marquee rental include chairs, tables and lighting?",
+        a: "Some packages include seating, carpet and lighting while others price these separately, so always get an itemised list. Confirm exactly what arrives so you can arrange anything missing in time.",
+      },
+      {
+        q: "How much space do I need for a marquee at home?",
+        a: "The required ground depends on your guest count and the seating layout, plus room for catering and a stage. Share your expected numbers and the site with the rental team in {city} so they can recommend the right size.",
+      },
+      {
+        q: "Can the marquee handle rain or cold weather?",
+        a: "Wall-sided tents, waterproof covers and heaters or coolers help manage weather, which matters for outdoor functions. Ask the provider about their contingency plan, especially for winter weddings or if rain is possible.",
+      },
+    ],
+  },
+
+  "Decorator": {
+    intro:
+      "A wedding decorator in {city} shapes the entire visual mood of your mehndi, barat and walima — from the stage and backdrop to flowers, lighting and entrance. Distinctive themes and prime dates book out early in the October–March season, so share your vision well ahead of time.",
+    ask: [
+      "Look at photos of past setups that match your theme and budget, and confirm the decorator can recreate the stage, backdrop and lighting style you want.",
+      "Clarify exactly what's included — flowers (fresh or artificial), lighting, drapes, props and table decor — versus what costs extra.",
+      "Ask how much setup time they need at the venue in {city} and whether they coordinate with the venue's own rules on timing and fixtures.",
+      "Confirm whether they handle separate decor for multiple functions, the advance, and the cancellation or change policy in writing.",
+    ],
+    faqs: [
+      {
+        q: "Can the decorator match a specific theme or colour palette?",
+        a: "Most decorators in {city} will work to a theme or palette you share, so bring reference photos to align expectations. Discuss what is achievable within your budget so the final setup matches your vision.",
+      },
+      {
+        q: "Are fresh flowers or artificial decor used?",
+        a: "Decorators offer both, and the choice affects look, longevity and cost — fresh flowers feel premium but artificial holds up longer in heat. Ask what they recommend for your stage and season.",
+      },
+      {
+        q: "How much time does decoration setup need at the venue?",
+        a: "Elaborate stages and floral work take several hours, so the decorator needs venue access well before guests arrive. Confirm the setup window with both the decorator and your venue in {city} to avoid clashes.",
+      },
+    ],
+  },
+
+  "Florist": {
+    intro:
+      "A florist for your wedding in {city} provides the fresh blooms that bring stages, cars, bouquets and garlands to life across the mehndi, barat and walima. Flower quality and freshness on the day matter most, and demand peaks sharply during the October–March wedding season.",
+    ask: [
+      "Confirm whether the florist uses fresh or imported flowers, and how they keep them fresh from arrangement until your function in {city}.",
+      "Discuss exactly what you need — stage florals, bridal bouquet, car decor, table centerpieces, sehra or garlands (haar) for the nikah and doli.",
+      "Ask about seasonal availability, since some flowers are harder to source in certain months, and what alternatives they suggest.",
+      "Clarify delivery and on-site setup timing, the advance, and the policy if a particular flower is unavailable on the day.",
+    ],
+    faqs: [
+      {
+        q: "Will the flowers stay fresh through the whole function?",
+        a: "Good florists time their preparation and use proper handling so arrangements look fresh when guests arrive, which is important in warm weather. Ask how they manage freshness from delivery through the event in {city}.",
+      },
+      {
+        q: "Can I get specific or imported flowers for my wedding?",
+        a: "Many florists can source imported or specific blooms, but availability depends on the season and lead time. Share your preferences early so they can confirm what's possible and suggest alternatives if needed.",
+      },
+      {
+        q: "Does the florist provide garlands and sehra too?",
+        a: "Many offer garlands (haar) for the stage, nikah and doli, plus the groom's sehra, alongside bouquets and centerpieces. Confirm the full list you need so nothing is missed for your barat or walima.",
+      },
+    ],
+  },
+
+  "Generator rental": {
+    intro:
+      "A generator rental in {city} is essential insurance against load-shedding and power cuts that could otherwise interrupt your wedding lights, AC and sound. The right backup keeps the function running smoothly, and demand is high through the October–March season, so reserve a unit early.",
+    ask: [
+      "Confirm the generator's capacity (KVA) is sufficient to run the venue lights, AC, sound and catering equipment together without overload.",
+      "Ask whether fuel is included or billed separately, and whether an operator stays on-site throughout your function in {city} to manage it.",
+      "Clarify whether it's sound-proofed (so noise doesn't disturb the function) and whether the unit is outdoor-rated for lawn or marquee setups.",
+      "Discuss delivery, pickup and setup timing, a backup unit in case of failure, and lock the advance and cancellation terms in writing.",
+    ],
+    faqs: [
+      {
+        q: "What size generator do I need for my wedding?",
+        a: "The right KVA depends on the combined load of lights, AC, sound and kitchen equipment, so share your venue and equipment list. A reliable rental in {city} will calculate the capacity and suggest a margin so nothing trips during peak load.",
+      },
+      {
+        q: "Is fuel included in the generator rental?",
+        a: "Fuel is sometimes included and sometimes billed by usage, so confirm this upfront to avoid surprises. Also ask whether an operator stays on-site to refuel and handle any issues during the function.",
+      },
+      {
+        q: "Will the generator be noisy during the function?",
+        a: "Sound-proofed (canopied) units run much quieter and are better suited to weddings where guests are nearby. Ask whether the unit is sound-proofed and where it will be placed so noise doesn't disturb your event.",
+      },
+    ],
+  },
+
+  "Bridal wearing": {
+    intro:
+      "Your bridal outfit is the centrepiece of your barat or walima, so choosing the right designer or boutique in {city} for your lehenga, gharara or maxi is a key decision. Custom and made-to-order bridal wear needs a long lead time, especially during the busy October–March season.",
+    ask: [
+      "Confirm the lead time needed for a custom outfit and build in buffer for fittings, since detailed bridal embroidery and beadwork take weeks or months.",
+      "Clarify whether the price covers the full ensemble — shirt, dupatta, lehenga and inner — or whether items are charged separately.",
+      "Ask about trial and fitting sessions, alteration policy, and how close to the wedding the final fitting happens so the fit is perfect.",
+      "Discuss whether they offer rental options, groom or family outfits, and the advance, delivery and cancellation terms for your wedding in {city}.",
+    ],
+    faqs: [
+      {
+        q: "How early should I order my bridal outfit in {city}?",
+        a: "Custom bridal wear with heavy embroidery needs a generous lead time, so order well ahead and allow extra weeks for fittings and finishing. During peak wedding season in {city}, designers' calendars fill quickly, so the earlier the better.",
+      },
+      {
+        q: "Are alterations and fittings included?",
+        a: "Many boutiques include trial fittings and minor alterations, but confirm the policy and how many fittings are offered. A final fitting close to the wedding helps ensure the outfit sits perfectly on the day.",
+      },
+      {
+        q: "Can I rent a bridal outfit instead of buying?",
+        a: "Some boutiques in {city} offer rental for bridal and family outfits, which can be a practical option for a one-time wear. Ask about availability, sizing, the security deposit and the return condition required.",
+      },
+    ],
+  },
+
+  "Wedding cakes": {
+    intro:
+      "A wedding cake adds a memorable centrepiece to the reception and cake-cutting moment at your function in {city}. Custom tiered and themed cakes need to be ordered ahead, and demand rises during the October–March wedding season, so book your design early.",
+    ask: [
+      "Discuss the design, number of tiers and finish (fondant for a sculpted look or fresh cream for a softer taste) so the cake matches your theme.",
+      "Ask about a tasting and the flavour options, and confirm whether eggless or other dietary versions are available for your guests.",
+      "Confirm the minimum order size for your guest count and whether delivery and on-site setup at your venue in {city} are included.",
+      "Clarify how the cake is kept stable and fresh in warm weather, the advance, and the policy if the design needs a last-minute change.",
+    ],
+    faqs: [
+      {
+        q: "How far ahead should I order a wedding cake?",
+        a: "Custom and tiered cakes need to be ordered well in advance so the design and tasting can be finalised. During peak season in {city}, bakers' slots fill fast, so confirming early secures both your date and your design.",
+      },
+      {
+        q: "Is a cake tasting available before I order?",
+        a: "Many bakers offer a tasting so you can choose your flavour and confirm quality before committing. Ask whether the tasting is free, paid or credited toward your order.",
+      },
+      {
+        q: "Can the cake be delivered and set up at the venue?",
+        a: "Tiered cakes are often delivered and assembled on-site to avoid damage in transit, but confirm whether this is included. Discuss how the baker keeps the cake stable and fresh in warm weather at your venue in {city}.",
+      },
+    ],
+  },
+
+  "Henna artist": {
+    intro:
+      "A henna (mehndi) artist in {city} creates the intricate bridal designs that are a treasured part of the mehndi function and the days leading up to the wedding. Booking the right artist early matters most during the October–March season, when bridal slots fill quickly.",
+    ask: [
+      "Review photos of the artist's bridal work to confirm their style — traditional, Arabic, Indo-Arabic or modern — matches the design you have in mind.",
+      "Confirm whether they use natural henna for a rich, safe stain, and how long before the function the application should happen for the colour to deepen.",
+      "Ask how many hours detailed bridal hands and feet take, and whether they bring a team for the bridesmaids and family at your mehndi in {city}.",
+      "Clarify whether they travel to your home or venue, the advance, and the date-lock and cancellation terms.",
+    ],
+    faqs: [
+      {
+        q: "When should the bridal mehndi be applied before the wedding?",
+        a: "Bridal henna is usually applied a day or two before so the stain has time to darken to its richest colour. Your artist in {city} can advise the best timing based on the design and how deep a stain you want.",
+      },
+      {
+        q: "Is natural henna safer and better than chemical cones?",
+        a: "Natural, well-prepared henna gives a safe, deep stain and avoids skin reactions linked to some chemical 'black henna' cones. Ask your artist what they use, especially if you have sensitive skin.",
+      },
+      {
+        q: "Can the artist also do mehndi for family and guests?",
+        a: "Many bridal artists bring a team to apply simpler designs for bridesmaids and family during the mehndi function. Confirm the number of guests and the time needed so everyone is covered without a rush.",
+      },
+    ],
+  },
+
+  "Qawwali and Naat": {
+    intro:
+      "A Qawwali or Naat performance brings a devotional, soulful atmosphere to a wedding evening, mehfil or pre-wedding gathering in {city}. Choosing performers whose repertoire and style suit your family sets the right spiritual tone, and skilled troupes are booked early for the October–March season.",
+    ask: [
+      "Discuss the repertoire and style you want — classic Sufi qawwali, Naat-khwani or a mix — and confirm the troupe is comfortable with your family's preferences.",
+      "Ask about the troupe size, the instruments used (harmonium, tabla, dholak) and the languages they perform in, such as Urdu, Punjabi, Persian or Arabic.",
+      "Confirm whether they bring their own sound system or need one arranged at your venue in {city}, and how the seating should be set for the mehfil.",
+      "Clarify the session length, whether the seating can accommodate a respectful female arrangement, the advance and the cancellation terms.",
+    ],
+    faqs: [
+      {
+        q: "What's the difference between Qawwali and Naat at a wedding?",
+        a: "Qawwali is a devotional Sufi performance with rhythm and chorus, while Naat is the recitation of poetry in praise of the Prophet (peace be upon him), often softer in tone. Many gatherings include both, so discuss the balance you'd like for your evening.",
+      },
+      {
+        q: "Do the performers bring their own sound system?",
+        a: "Some troupes carry their own equipment while others expect the venue to provide it, so confirm this in advance. Coordinating sound early avoids last-minute issues at your mehfil in {city}.",
+      },
+      {
+        q: "Can the seating respect a separate female arrangement?",
+        a: "Many families prefer a respectful seating layout, and experienced troupes are comfortable performing for such arrangements. Discuss your family's preferences when booking so the setup is planned accordingly.",
+      },
+    ],
+  },
+
+  "Sound system rental": {
+    intro:
+      "A sound system rental in {city} ensures the nikah, speeches, music and announcements are heard clearly across your mehndi, barat or walima. Matching the equipment to your venue size and crowd is what makes the difference, and good setups are booked early in the October–March season.",
+    ask: [
+      "Confirm the number and power of speakers suits your guest count and venue, so the sound carries across a large hall or open lawn without distortion.",
+      "Ask how many wireless mics are included for the nikah, MC and speeches, and whether a mixer and operator come with the setup.",
+      "Clarify whether stage lighting, a DJ booth or extra add-ons are part of the package or charged separately for your function in {city}.",
+      "Confirm that an operator stays on-site to manage levels, that the gear is outdoor-rated if needed, and lock the timing, advance and cancellation terms.",
+    ],
+    faqs: [
+      {
+        q: "How do I know the sound system is the right size for my venue?",
+        a: "The speaker count and wattage should match your guest numbers and whether the venue is indoor or open-air. Share these details with the provider in {city} so they recommend a setup that covers the space clearly.",
+      },
+      {
+        q: "Is an operator included to run the sound?",
+        a: "A trained operator who manages mic levels and music transitions makes a big difference, but isn't always included by default. Confirm whether an on-site operator comes with the rental so the audio runs smoothly all evening.",
+      },
+      {
+        q: "Can the same setup handle the nikah, speeches and music?",
+        a: "Yes — a proper setup with enough wireless mics and a mixer can cover the nikah, announcements, speeches and music. Tell the provider what functions you need so they include the right number of mics and equipment.",
+      },
+    ],
+  },
+
+  "Dhol player": {
+    intro:
+      "A dhol player brings the unmistakable energy of a Pakistani wedding, setting the rhythm for the dholki, mehndi, baraat entrance and doli in {city}. Booking a skilled dhol performer early matters during the October–March season, when weekend dates are in high demand.",
+    ask: [
+      "Confirm how many dholis you need for the size and energy of your function, since a large baraat often calls for more than one performer.",
+      "Clarify which events they cover — dholki, mehndi, the baraat entrance and the doli — and how many hours of performance are included.",
+      "Ask whether they wear traditional attire for a fitting look and whether they bring complementary instruments like the naal or dholki.",
+      "Confirm whether they accept female-only functions if needed, and lock the timing, arrival window, advance and cancellation terms for your event in {city}.",
+    ],
+    faqs: [
+      {
+        q: "How many dhol players do I need for my wedding?",
+        a: "One dhol player suits a smaller gathering, while a large baraat or mehndi often feels better with two or more for fuller energy. Share your guest count and the moments you want covered so the provider in {city} can advise.",
+      },
+      {
+        q: "Which functions does the dhol player cover?",
+        a: "Dhol performers commonly cover the dholki, mehndi, the baraat entrance and the doli send-off, with a set number of hours included. Confirm exactly which events and timings you need so the booking matches your schedule.",
+      },
+      {
+        q: "Can a dhol player perform at a female-only function?",
+        a: "Some dhol performers accommodate female-only events depending on your family's preferences, so ask when booking. Confirm this in advance so the arrangement respects your family's wishes for the mehndi or dholki.",
+      },
+    ],
+  },
+
+  "Wedding Invitations and Stationery": {
+    intro:
+      "Wedding invitations and stationery set the first impression of your celebration, from the nikah and barat cards to mehndi invites, bid boxes and favour packaging in {city}. Designing and printing well-finished cards takes time, so order early — especially before the October–March wedding rush.",
+    ask: [
+      "Confirm the production turnaround and finalise your guest list early, since custom designs, printing and any laser-cut or foil finishes take time.",
+      "Clarify whether you want separate cards for each event (nikah, barat, walima, mehndi) or a combined multi-event design, and whether matching envelopes are included.",
+      "Ask about printing in Urdu, English or bilingual text, and whether they handle calligraphy, foil stamping, acrylic or scroll-style premium formats.",
+      "Discuss the minimum order quantity, proofing before the full print run, delivery within {city} or by courier, and the advance and rush-order policy.",
+    ],
+    faqs: [
+      {
+        q: "How early should I order wedding invitations in {city}?",
+        a: "Order well ahead so there's time to finalise the design, approve a proof, complete the print run and still distribute cards with notice. Custom finishes like laser-cutting, foil or scroll boxes need extra lead time, and peak season slows turnaround.",
+      },
+      {
+        q: "Can I get separate cards for the nikah, barat and walima?",
+        a: "Yes — many stationers design event-specific cards or a combined multi-event invite, along with matching mehndi cards and favour boxes. Decide which functions need their own card so the quantities and design are planned correctly.",
+      },
+      {
+        q: "Will I see a proof before the full print run?",
+        a: "Reputable stationers share a proof so you can check names, dates, wording and the Urdu or English text before printing everything. Always review the proof carefully, as corrections after the full run cost time and money.",
+      },
+    ],
+  },
+};
+
+export function getVendorGuidance(type?: string | null): VendorTypeGuidance | null {
+  if (!type) return null;
+  return VENDOR_TYPE_GUIDANCE[type] ?? null;
+}


### PR DESCRIPTION
- Claim & complete wizard (/claim/[id]), set-password, admin claims queue (flag-gated NEXT_PUBLIC_CLAIM_ENABLED, default off)
- Per-type guidance + FAQ + FAQPage schema on vendor detail + SEO leaf pages (lib/seo/vendor-type-guidance.ts)
- noindex,follow on thin app UX routes (vendorListings) so canonical SEO routes rank
- VendorDetailsMobile: honest empty states, true About, guidance/FAQ, claim CTA, honest Verified gating
- SEO program docs (docs/seo/2026-06-rank-everything)

Additive + flag-gated; claim features dark by default.