### PR TITLE
fix(images): allow-list res.cloudinary.com in next/image remotePatterns

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -36,8 +36,12 @@ const nextConfig = {
       // Localhost dev is included so local builds don't 500 on backend
       // image references.
       { protocol: "http", hostname: "localhost" },
-      // TODO: add the production CDN hostname once vendor uploads move
-      // off the API origin (e.g. cdn.weddingwala.pk or an S3/R2 bucket).
+      // Cloudinary — vendor media (imported listing images + all uploads:
+      // profiles, business galleries, review photos, KYC, booking milestones)
+      // is stored on Cloudinary so it survives Railway redeploys. next/image
+      // refuses to optimize any host not listed here, so these URLs MUST be
+      // allow-listed or every vendor image renders broken.
+      { protocol: "https", hostname: "res.cloudinary.com" },
     ],
   },
   experimental: {


### PR DESCRIPTION
All vendor media (imported listing images + every upload flow) now lives on Cloudinary, but next/image refused the host, so the optimizer returned 400 for every vendor image and cards fell back to placeholder.svg on the live site. Adding res.cloudinary.com makes the imported 3,268 vendors' photos render.